### PR TITLE
Use glob patterns in gitignore for target/ and broadcast/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-target/
+target/*
 node_modules/
 bun.lock
 contracts/out/
 contracts/cache/
-contracts/broadcast/
+contracts/broadcast/*
 .env


### PR DESCRIPTION
## Summary
- Changed `target/` → `target/*` and `contracts/broadcast/` → `contracts/broadcast/*` in `.gitignore`

## Test plan
- [x] Gitignore still excludes the intended files