### PR TITLE
Add /checklist skill for CLAUDE.md rules verification

### DIFF
--- a/.claude/skills/checklist/SKILL.md
+++ b/.claude/skills/checklist/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: checklist
+description: Run the CLAUDE.md rules checklist to verify nothing was missed before pushing or opening a PR
+user_invocable: true
+---
+
+If the user is invoking this skill, it means you have likely been sloppy about respecting the instructions in CLAUDE.md. Refresh your memory on the checklist below and work through every item carefully.
+
+## Rules Checklist (mirrored from CLAUDE.md)
+
+1. **After every change**, update `README.md` and `CLAUDE.md` if the change affects documented behavior, architecture, or setup.
+2. **Every PR** must include an entry in `docs/changeset.md` describing what was added/changed.
+3. **Every prompt** from the user must be saved verbatim to `docs/prompts/<branch-name>/` as a `.txt` file. Filename format: `{timestamp-seconds}-{slug}.txt`. Organize by feature branch name.
+4. **When submitting PRs**, write them in the chat for user review. User may leave comments here or on GitHub.
+5. **Branch strategy**: Be intentional about what branch you're working off of. Usually `main`, but agents may stack on each other when dependencies exist.
+6. **All git branches** must be prefixed with `cdai__` (e.g., `cdai__add-contracts`).
+7. **Every task ends with a PR**. After completing work, push the branch and open a PR. GitHub is source of truth — no code goes to main without review.
+8. **`scripts/ci.sh` and `.github/workflows/ci.yml` must stay in sync.** If you change one, update the other. The local script mirrors the GitHub workflow exactly so you can validate before pushing.
+9. **Run `./scripts/ci.sh` locally before pushing any commits or opening PRs.** CI must pass locally first. No exceptions. If you break CI, fix it before pushing.
+
+## How to use this checklist
+
+Go through each item and verify compliance for the current branch/task:
+
+- [ ] Read `CLAUDE.md` rules section fresh
+- [ ] Check all user prompts in this conversation are saved to `docs/prompts/<branch-name>/`
+- [ ] Check `docs/changeset.md` has an entry for this PR
+- [ ] Check `README.md` and `CLAUDE.md` are updated if behavior/architecture/setup changed
+- [ ] Verify branch name has `cdai__` prefix
+- [ ] If `scripts/ci.sh` or `.github/workflows/ci.yml` was modified, verify they are in sync
+- [ ] Run `./scripts/ci.sh` and confirm it passes
+- [ ] Write the PR description in chat for user review before creating on GitHub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@
 8. **`scripts/ci.sh` and `.github/workflows/ci.yml` must stay in sync.** If you change one, update the other. The local script mirrors the GitHub workflow exactly so you can validate before pushing.
 9. **Run `./scripts/ci.sh` locally before pushing any commits or opening PRs.** CI must pass locally first. No exceptions. If you break CI, fix it before pushing.
 
+> **Keep in sync**: Whenever you add or change anything in this Rules checklist, also update the skill at `.claude/skills/checklist/SKILL.md`.
+
 ## Tech Stack
 
 ### Contracts

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-14 — Add `/checklist` skill
+- Added `.claude/skills/checklist/SKILL.md` — user-invocable skill that mirrors the CLAUDE.md rules checklist, for quick verification before pushing or opening PRs
+- Added sync note to CLAUDE.md: any changes to the rules checklist must also be reflected in the skill
+
 ### 2026-03-14 — Bracket spacing + sbytes8 fix (seismic-viem PR)
 - **Bracket spacing**: Increased R64 vertical gap from 2px to 8px (desktop) / 6px (mobile), and bumped later rounds proportionally. Games no longer appear jammed together.
 - **sbytes8 bug**: Root-caused to seismic-viem v1.1.1 missing `sbytes*` in `remapSeismicAbiInputs`. Fix submitted upstream: SeismicSystems/seismic#117 (v1.1.2). Will update dep when published.

--- a/docs/prompts/cdai__add-checklist-skill/1741952400-add-checklist-skill.txt
+++ b/docs/prompts/cdai__add-checklist-skill/1741952400-add-checklist-skill.txt
@@ -1,0 +1,5 @@
+check out to a new branch off of main. i want you to add a skill to the repo at <repo-root>/.claude/skills/checklist/SKILL.md
+
+it should essentially say, "if the user is invoking this skill, it means you have likely been sloppy about respecting the instructions in claude.md. so you should refresh your memory on that checklist." to save steps, you should duplicate the actual checklist content in claude.md to this skill; and then insert right UNDER claude.md a statement that says: "whenever you add anythihng to this chcekclist, you should also updat the skill at .claude/skills/checklist/SKILL.md
+
+after you add the skill, you should obviously work through the checklist itself


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/checklist/SKILL.md` — a user-invocable `/checklist` skill that mirrors the CLAUDE.md rules, for quick verification before pushing or opening PRs
- Adds a sync note to CLAUDE.md: any changes to the rules checklist must also be reflected in the skill

## Test plan
- [ ] Verify `/checklist` appears in available skills
- [ ] Invoke `/checklist` and confirm it walks through all 9 rules