### PR TITLE
Fix [object Object] in error display

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Fix [object Object] in error display
+- Error extraction now JSON.stringifies all non-string values so object details render as readable JSON instead of `[object Object]`
+- Unrecognized error objects without standard fields are dumped in full
+
 ### 2026-03-15 — Mobile header dropdown + better error surfacing
 - **Header**: On mobile, replaced inline buttons (Faucet, address, Connect/Disconnect) with a hamburger dropdown menu to prevent text overlap on small screens. Desktop layout unchanged.
 - **Error handling**: Added `extractErrorMessage` helper that walks the error cause chain to surface the real error from Privy/viem instead of showing generic "An error has occurred" messages. Errors now show in a scrollable container on mobile.

--- a/docs/prompts/cdai__fix-error-object-display/1742000800-object-object-error.txt
+++ b/docs/prompts/cdai__fix-error-object-display/1742000800-object-object-error.txt
@@ -1,0 +1,1 @@
+i deployed here's the error for you: An internal error was received. → details: [object Object].... wait this seems less informative than before!!! wtf

--- a/packages/web/src/hooks/useContract.ts
+++ b/packages/web/src/hooks/useContract.ts
@@ -31,25 +31,33 @@ export function useContract() {
 
   // Extract full error detail from nested/wrapped errors (Privy, viem, etc.)
   // Returns all messages in the cause chain so we can debug on mobile.
+  // Serializes objects to JSON so we never get "[object Object]".
+  const stringify = (v: unknown): string => {
+    if (typeof v === "string") return v;
+    try { return JSON.stringify(v); } catch { return String(v); }
+  };
   const extractErrorMessage = (err: unknown, fallback: string): string => {
     if (!err) return fallback;
     const parts: string[] = [];
     let current: unknown = err;
     for (let i = 0; i < 8 && current; i++) {
       if (current instanceof Error) {
-        const e = current as Error & { shortMessage?: string; details?: string; cause?: unknown };
-        if (e.shortMessage) parts.push(e.shortMessage);
+        const e = current as Error & { shortMessage?: unknown; details?: unknown; cause?: unknown };
+        if (e.shortMessage) parts.push(stringify(e.shortMessage));
         else if (e.message) parts.push(e.message);
-        if (e.details) parts.push(`details: ${e.details}`);
+        if (e.details) parts.push(`details: ${stringify(e.details)}`);
         current = e.cause;
       } else if (typeof current === "object" && current !== null) {
         const obj = current as Record<string, unknown>;
-        if (typeof obj.shortMessage === "string") parts.push(obj.shortMessage);
-        else if (typeof obj.message === "string") parts.push(obj.message);
-        if (typeof obj.details === "string") parts.push(`details: ${obj.details}`);
+        if (obj.shortMessage) parts.push(stringify(obj.shortMessage));
+        else if (obj.message) parts.push(stringify(obj.message));
+        if (obj.details) parts.push(`details: ${stringify(obj.details)}`);
+        if (!obj.shortMessage && !obj.message && !obj.details) {
+          parts.push(stringify(obj));
+        }
         current = obj.cause;
       } else {
-        parts.push(String(current));
+        parts.push(stringify(current));
         break;
       }
     }


### PR DESCRIPTION
## Summary
- Error details from viem/Privy can be objects, not strings — was rendering as `[object Object]`
- Now JSON.stringifies all non-string values so the actual error content is visible
- Unrecognized error objects without standard fields are dumped in full as JSON

## Test plan
- [ ] Trigger a tx error on mobile and verify the details show as readable JSON