### PR TITLE
Fix desktop bracket layout: converging regions + flat submit bar

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,11 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Desktop bracket layout redesign
+- **Bracket convergence**: Fixed double-reversal bug in `BracketRegion` — right-side regions (West, Midwest) now correctly flow inward toward the center where the champion is crowned, matching standard bracket app convention.
+- **Submit panel**: Redesigned as a compact horizontal bar on desktop (mobile layout unchanged). Progress, status, entry fee, tag input, and submit button all in one thin row.
+- **Removed scoreboard footer**: Removed the placeholder scoreboard section — will revisit later.
+
 ### 2026-03-15 — Fix Buffer polyfill for Privy signing
 - **Root cause**: Privy's embedded wallet signer calls `Buffer.from()` internally when signing EIP-712 typed data. `Buffer` is a Node.js global not available in browsers.
 - Added `buffer` package as devDependency

--- a/docs/prompts/cdai__desktop-bracket-layout/1742054400-desktop-bracket-redesign.txt
+++ b/docs/prompts/cdai__desktop-bracket-layout/1742054400-desktop-bracket-redesign.txt
@@ -1,0 +1,7 @@
+next thing we want to do:
+
+desktop appp looks gross. generally speaking the way bracket apps are done is.... regions on the RIGHT side of the screen have their games move leftwards -- so both sides are moving IN to the center, where the champion is crowned. so you should fix desktop mode to make it do that. also other things:
+
+2a) the "picks made" and submit picks thing seems way more optimized for mobile. thing it should be flatter (e.g. less tall and more spread across the screen, in a thin way) or just entirely re-thought. it just looks so out of place right now. we want to focus on the bracket for this view
+
+2b) the scoreboard footer is really offputting. it makes no sense to display "winners" down there. i also don't like "top score" i think remove the entire footer -- we'll think about that later.

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,7 +4,6 @@ import { BracketView } from "./components/BracketView";
 import { DeadlineCountdown } from "./components/DeadlineCountdown";
 import { FaucetBanner } from "./components/FaucetBanner";
 import { Header } from "./components/Header";
-import { Scoreboard } from "./components/Scoreboard";
 import { SubmitPanel } from "./components/SubmitPanel";
 import { useBracket } from "./hooks/useBracket";
 import { useContract } from "./hooks/useContract";
@@ -36,36 +35,34 @@ export default function App() {
           <FaucetBanner address={contract.walletAddress!} />
         )}
 
-        {/* Top bar: countdown + submit panel */}
-        <div className="flex flex-col lg:flex-row gap-4 mb-6 sm:mb-8">
-          <div className="flex-1 flex items-start gap-2 sm:gap-4">
-            <DeadlineCountdown />
-            <div className="flex items-center gap-2">
-              <button
-                onClick={bracket.resetPicks}
-                className="px-3 py-2 text-xs rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
-              >
-                Reset Picks
-              </button>
-            </div>
-          </div>
-          <div className="w-full lg:w-80">
-            <SubmitPanel
-              isComplete={bracket.isComplete}
-              pickCount={bracket.pickCount}
-              hasSubmitted={contract.hasSubmitted}
-              isLoading={contract.isLoading}
-              isBracketLoading={contract.isBracketLoading}
-              error={contract.error}
-              encodedBracket={bracket.encodedBracket}
-              existingBracket={contract.existingBracket}
-              onSubmit={contract.submitBracket}
-              onUpdate={contract.updateBracket}
-              onSetTag={contract.setTag}
-              onLoadBracket={handleLoadBracket}
-              walletConnected={authenticated}
-            />
-          </div>
+        {/* Top bar: countdown + reset */}
+        <div className="flex items-center gap-2 sm:gap-4 mb-4">
+          <DeadlineCountdown />
+          <button
+            onClick={bracket.resetPicks}
+            className="px-3 py-2 text-xs rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+          >
+            Reset Picks
+          </button>
+        </div>
+
+        {/* Submit panel — full width horizontal bar on desktop */}
+        <div className="mb-6 sm:mb-8">
+          <SubmitPanel
+            isComplete={bracket.isComplete}
+            pickCount={bracket.pickCount}
+            hasSubmitted={contract.hasSubmitted}
+            isLoading={contract.isLoading}
+            isBracketLoading={contract.isBracketLoading}
+            error={contract.error}
+            encodedBracket={bracket.encodedBracket}
+            existingBracket={contract.existingBracket}
+            onSubmit={contract.submitBracket}
+            onUpdate={contract.updateBracket}
+            onSetTag={contract.setTag}
+            onLoadBracket={handleLoadBracket}
+            walletConnected={authenticated}
+          />
         </div>
 
         {/* Bracket */}
@@ -75,11 +72,6 @@ export default function App() {
           onPick={bracket.makePick}
           disabled={isLocked}
         />
-
-        {/* Scoreboard placeholder */}
-        <div className="mt-8 sm:mt-12">
-          <Scoreboard entryCount={contract.entryCount} />
-        </div>
       </main>
     </div>
   );

--- a/packages/web/src/components/BracketRegion.tsx
+++ b/packages/web/src/components/BracketRegion.tsx
@@ -26,10 +26,10 @@ export function BracketRegion({
 
   return (
     <div className="flex flex-col">
-      <h3 className="text-sm font-semibold text-accent uppercase tracking-wider mb-3 px-1">
+      <h3 className={`text-sm font-semibold text-accent uppercase tracking-wider mb-3 px-1 ${reversed ? "text-right" : ""}`}>
         {regionName}
       </h3>
-      <div className={`flex ${reversed ? "flex-row-reverse" : "flex-row"} items-center gap-1`}>
+      <div className="flex flex-row items-center gap-1">
         {orderedRounds.map((roundGames, displayIdx) => {
           const actualRoundIdx = reversed
             ? rounds.length - 1 - displayIdx

--- a/packages/web/src/components/SubmitPanel.tsx
+++ b/packages/web/src/components/SubmitPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { ENTRY_FEE_DISPLAY, SUBMISSION_DEADLINE } from "../lib/constants";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 interface SubmitPanelProps {
   isComplete: boolean;
@@ -36,6 +37,7 @@ export function SubmitPanel({
   const [tag, setTag] = useState("");
   const [tagSaved, setTagSaved] = useState(false);
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const isMobile = useIsMobile();
 
   const isLocked = Date.now() / 1000 >= SUBMISSION_DEADLINE;
 
@@ -65,23 +67,200 @@ export function SubmitPanel({
     }
   };
 
+  if (isMobile) {
+    return (
+      <MobileSubmitPanel
+        isComplete={isComplete}
+        pickCount={pickCount}
+        hasSubmitted={hasSubmitted}
+        isLoading={isLoading}
+        isBracketLoading={isBracketLoading}
+        error={error}
+        encodedBracket={encodedBracket}
+        existingBracket={existingBracket}
+        isLocked={isLocked}
+        submitSuccess={submitSuccess}
+        tag={tag}
+        tagSaved={tagSaved}
+        walletConnected={walletConnected}
+        onSubmit={handleSubmit}
+        onLoadBracket={onLoadBracket}
+        onSetTag={handleSetTag}
+        onTagChange={setTag}
+      />
+    );
+  }
+
+  // Desktop: compact horizontal bar
   return (
-    <div className="bg-bg-secondary border border-border rounded-xl p-4 sm:p-6 space-y-4">
+    <div className="bg-bg-secondary border border-border rounded-xl px-4 py-3">
+      <div className="flex items-center gap-4">
+        {/* Progress */}
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-xs text-text-secondary whitespace-nowrap">Picks</span>
+          <span className={`text-sm font-mono font-semibold ${isComplete ? "text-success" : "text-text-primary"}`}>
+            {pickCount}/63
+          </span>
+          <div className="w-24 bg-bg-tertiary rounded-full h-1.5">
+            <div
+              className={`h-1.5 rounded-full transition-all duration-300 ${isComplete ? "bg-success" : "bg-accent"}`}
+              style={{ width: `${(pickCount / 63) * 100}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Status badges */}
+        {hasSubmitted && (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-success/20 text-success border border-success/30 whitespace-nowrap">
+            Submitted
+          </span>
+        )}
+        {isLocked && (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-danger/20 text-danger border border-danger/30 whitespace-nowrap">
+            Locked
+          </span>
+        )}
+
+        {/* Entry fee (before first submission) */}
+        {!hasSubmitted && !isLocked && (
+          <span className="text-xs text-text-muted whitespace-nowrap">
+            Entry: <span className="font-semibold text-text-primary">{ENTRY_FEE_DISPLAY}</span>
+          </span>
+        )}
+
+        <div className="flex-1" />
+
+        {/* Load existing bracket */}
+        {hasSubmitted && !existingBracket && (
+          <button
+            onClick={onLoadBracket}
+            disabled={isBracketLoading}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border whitespace-nowrap ${
+              isBracketLoading
+                ? "bg-bg-tertiary text-text-muted cursor-wait border-border"
+                : "bg-bg-tertiary text-text-primary border-border hover:bg-bg-hover hover:border-accent/50"
+            }`}
+          >
+            {isBracketLoading ? "Loading..." : "Load my bracket"}
+          </button>
+        )}
+
+        {/* Tag input (after submission) */}
+        {hasSubmitted && !isLocked && (
+          <div className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+              placeholder="Display name"
+              maxLength={32}
+              className="w-32 px-2 py-1.5 text-xs rounded-lg bg-bg-tertiary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
+            />
+            <button
+              onClick={handleSetTag}
+              disabled={!tag.trim() || isLoading}
+              className="px-2 py-1.5 text-xs rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              {tagSaved ? "Saved!" : "Set Tag"}
+            </button>
+          </div>
+        )}
+
+        {/* Submit / Update button */}
+        {!isLocked && (
+          <button
+            onClick={handleSubmit}
+            disabled={!isComplete || isLoading || !walletConnected}
+            className={`px-5 py-1.5 rounded-lg font-semibold text-xs transition-all whitespace-nowrap ${
+              !isComplete || !walletConnected
+                ? "bg-bg-tertiary text-text-muted cursor-not-allowed border border-border"
+                : isLoading
+                  ? "bg-accent/50 text-white cursor-wait"
+                  : submitSuccess
+                    ? "bg-success text-white"
+                    : "bg-accent text-white hover:bg-accent-hover"
+            }`}
+          >
+            {isLoading
+              ? "Submitting..."
+              : submitSuccess
+                ? "Success!"
+                : !walletConnected
+                  ? "Connect wallet"
+                  : !isComplete
+                    ? `${63 - pickCount} picks left`
+                    : hasSubmitted
+                      ? "Update Bracket"
+                      : `Submit (${ENTRY_FEE_DISPLAY})`}
+          </button>
+        )}
+      </div>
+
+      {/* Error row */}
+      {error && (
+        <div
+          onClick={() => { navigator.clipboard.writeText(error); }}
+          className="mt-2 bg-danger/10 border border-danger/30 rounded-lg px-3 py-2 text-xs text-danger max-h-20 overflow-y-auto break-words cursor-pointer active:bg-danger/20"
+        >
+          <span className="font-semibold">Error (tap to copy):</span> {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Mobile: keep the existing card layout ──────────── */
+
+function MobileSubmitPanel({
+  isComplete,
+  pickCount,
+  hasSubmitted,
+  isLoading,
+  isBracketLoading,
+  error,
+  encodedBracket,
+  existingBracket,
+  isLocked,
+  submitSuccess,
+  tag,
+  tagSaved,
+  walletConnected,
+  onSubmit,
+  onLoadBracket,
+  onSetTag,
+  onTagChange,
+}: {
+  isComplete: boolean;
+  pickCount: number;
+  hasSubmitted: boolean;
+  isLoading: boolean;
+  isBracketLoading: boolean;
+  error: string | null;
+  encodedBracket: `0x${string}` | null;
+  existingBracket: `0x${string}` | null;
+  isLocked: boolean;
+  submitSuccess: boolean;
+  tag: string;
+  tagSaved: boolean;
+  walletConnected: boolean;
+  onSubmit: () => Promise<void>;
+  onLoadBracket: () => Promise<void>;
+  onSetTag: () => Promise<void>;
+  onTagChange: (v: string) => void;
+}) {
+  return (
+    <div className="bg-bg-secondary border border-border rounded-xl p-4 space-y-4">
       {/* Progress */}
       <div>
         <div className="flex justify-between text-sm mb-2">
           <span className="text-text-secondary">Picks made</span>
-          <span
-            className={`font-mono ${isComplete ? "text-success" : "text-text-primary"}`}
-          >
+          <span className={`font-mono ${isComplete ? "text-success" : "text-text-primary"}`}>
             {pickCount}/63
           </span>
         </div>
         <div className="w-full bg-bg-tertiary rounded-full h-2">
           <div
-            className={`h-2 rounded-full transition-all duration-300 ${
-              isComplete ? "bg-success" : "bg-accent"
-            }`}
+            className={`h-2 rounded-full transition-all duration-300 ${isComplete ? "bg-success" : "bg-accent"}`}
             style={{ width: `${(pickCount / 63) * 100}%` }}
           />
         </div>
@@ -101,7 +280,7 @@ export function SubmitPanel({
         )}
       </div>
 
-      {/* Load existing bracket button (only if submitted but not yet loaded) */}
+      {/* Load existing bracket */}
       {hasSubmitted && !existingBracket && (
         <button
           onClick={onLoadBracket}
@@ -116,13 +295,11 @@ export function SubmitPanel({
         </button>
       )}
 
-      {/* Entry fee notice */}
+      {/* Entry fee */}
       {!hasSubmitted && !isLocked && (
         <div className="bg-bg-tertiary rounded-lg p-3 border border-border">
           <div className="text-xs text-text-muted mb-1">Entry fee</div>
-          <div className="text-lg font-bold text-text-primary">
-            {ENTRY_FEE_DISPLAY}
-          </div>
+          <div className="text-lg font-bold text-text-primary">{ENTRY_FEE_DISPLAY}</div>
           <div className="text-xs text-text-muted mt-1">
             Prize pool split equally among highest-scoring brackets
           </div>
@@ -132,7 +309,7 @@ export function SubmitPanel({
       {/* Submit / Update button */}
       {!isLocked && (
         <button
-          onClick={handleSubmit}
+          onClick={onSubmit}
           disabled={!isComplete || isLoading || !walletConnected}
           className={`w-full py-3 rounded-lg font-semibold text-sm transition-all ${
             !isComplete || !walletConnected
@@ -158,23 +335,21 @@ export function SubmitPanel({
         </button>
       )}
 
-      {/* Tag input (only after submission) */}
+      {/* Tag input */}
       {hasSubmitted && !isLocked && (
         <div className="space-y-2">
-          <label className="text-xs text-text-muted">
-            Display name (optional)
-          </label>
+          <label className="text-xs text-text-muted">Display name (optional)</label>
           <div className="flex gap-2">
             <input
               type="text"
               value={tag}
-              onChange={(e) => setTag(e.target.value)}
+              onChange={(e) => onTagChange(e.target.value)}
               placeholder="Enter a display name"
               maxLength={32}
               className="flex-1 px-3 py-2 text-sm rounded-lg bg-bg-tertiary border border-border text-text-primary placeholder-text-muted focus:outline-none focus:border-accent"
             />
             <button
-              onClick={handleSetTag}
+              onClick={onSetTag}
               disabled={!tag.trim() || isLoading}
               className="px-4 py-2 text-sm rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -184,12 +359,10 @@ export function SubmitPanel({
         </div>
       )}
 
-      {/* Error display — tap to copy for mobile debugging */}
+      {/* Error display */}
       {error && (
         <div
-          onClick={() => {
-            navigator.clipboard.writeText(error);
-          }}
+          onClick={() => { navigator.clipboard.writeText(error); }}
           className="bg-danger/10 border border-danger/30 rounded-lg p-3 text-xs text-danger max-h-40 overflow-y-auto break-words cursor-pointer active:bg-danger/20"
         >
           <div className="font-semibold mb-1 text-sm">Error (tap to copy)</div>


### PR DESCRIPTION
## Summary
- **Bracket convergence bug fix**: Right-side regions (West, Midwest) had a double-reversal (`orderedRounds.reverse()` + `flex-row-reverse`) that cancelled out, making them display left-to-right just like left-side regions. Now they correctly flow inward toward the center where the champion is crowned.
- **Flat submit panel on desktop**: Redesigned from a tall sidebar card to a compact horizontal bar spanning the full width. Progress, status badges, entry fee, tag input, and submit button all in one thin row. Mobile layout unchanged.
- **Removed scoreboard footer**: The placeholder "Top Score" / "Winners" footer was distracting — will revisit after tournament results flow is built.

## Test plan
- [ ] Verify desktop bracket shows East/South flowing L→R and West/Midwest flowing R→L (converging to center)
- [ ] Verify submit panel is a thin horizontal bar on desktop
- [ ] Verify mobile bracket + submit panel unchanged
- [ ] Verify no scoreboard footer renders