### PR TITLE
Sim: configurable pace dispersion + score-dist calibration tool

### DIFF
--- a/crates/bracket-sim/Cargo.toml
+++ b/crates/bracket-sim/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/bin/calibrate.rs"
 name = "sim"
 path = "src/bin/sim.rs"
 
+[[bin]]
+name = "score-dist"
+path = "src/bin/score_dist.rs"
+
 [dependencies]
 rand = "0.9"
 rand_distr = "0.5"

--- a/crates/bracket-sim/src/bin/score_dist.rs
+++ b/crates/bracket-sim/src/bin/score_dist.rs
@@ -1,0 +1,158 @@
+//! Score distribution calibration tool.
+//!
+//! Sweeps pace dispersion values and reports game-level statistics
+//! (mean total, margin spread, OT frequency, etc.) so you can compare
+//! against empirical NCAA tournament data and pick the best-fit parameter.
+//!
+//! Known NCAA tournament empirical targets (approximate):
+//!   - Average total score:      ~140-145 points
+//!   - Average margin:           ~10-12 points (unsigned)
+//!   - Margin stddev:            ~12-13 points
+//!   - OT frequency:             ~5-7% of games
+//!   - Total stddev:             ~18-20 points
+
+use bracket_sim::bracket_config::{BracketConfig, DEFAULT_YEAR};
+use bracket_sim::load_teams_for_year;
+use bracket_sim::{Game, Tournament};
+use clap::Parser;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use std::io;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "score-dist")]
+#[command(about = "Sweep pace dispersion and report game score distributions")]
+struct Args {
+    /// Tournament year
+    #[arg(short = 'y', long, default_value_t = DEFAULT_YEAR)]
+    year: u16,
+
+    /// Path to combined teams CSV
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Games to simulate per dispersion value
+    #[arg(short, long, default_value_t = 50_000)]
+    n_games: usize,
+
+    /// Dispersion values to sweep (comma-separated)
+    #[arg(short, long, default_value = "0.3,0.5,0.7,0.8,0.9,1.0,1.2,1.5,2.0")]
+    d_values: String,
+
+    /// RNG seed for reproducibility
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+}
+
+struct GameStats {
+    total: f64,
+    margin: f64,
+    is_tie: bool,
+    pace: f64,
+}
+
+fn simulate_games(
+    games: &[Game],
+    pace_d: f64,
+    n_games: usize,
+    rng: &mut impl Rng,
+) -> Vec<GameStats> {
+    let mut stats = Vec::with_capacity(n_games);
+    let n_matchups = games.len();
+
+    for i in 0..n_games {
+        let game = &games[i % n_matchups];
+        let metrics = game.expected_t1_metrics();
+        let result = Game::simulate(metrics, pace_d, rng);
+
+        stats.push(GameStats {
+            total: (result.team1_score + result.team2_score) as f64,
+            margin: (result.team1_score as f64 - result.team2_score as f64).abs(),
+            is_tie: result.team1_score == result.team2_score,
+            pace: result.pace,
+        });
+    }
+
+    stats
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    let bracket_config = BracketConfig::for_year(args.year);
+    let teams = load_teams_for_year(args.input.as_deref(), args.year)?;
+
+    let mut tournament = Tournament::new();
+    tournament.setup_tournament(teams, &bracket_config);
+    let games = tournament.get_games().clone();
+
+    let d_values: Vec<f64> = args
+        .d_values
+        .split(',')
+        .map(|s| s.trim().parse::<f64>().expect("invalid dispersion value"))
+        .collect();
+
+    // Header
+    println!(
+        "\n{:>6}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}",
+        "d", "AvgTot", "TotSD", "AvgMgn", "MgnSD", "OT%", "AvgPace", "PaceSD", "P(0pts)"
+    );
+    println!("{}", "-".repeat(82));
+
+    // Empirical targets row
+    println!(
+        "{:>6}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}  {:>7}",
+        "REAL", "~142", "~19", "~11", "~12", "~6%", "~68", "?", "~0%"
+    );
+    println!("{}", "-".repeat(82));
+
+    for &d in &d_values {
+        let mut rng = StdRng::seed_from_u64(args.seed);
+        let stats = simulate_games(&games, d, args.n_games, &mut rng);
+        let n = stats.len() as f64;
+
+        let avg_total: f64 = stats.iter().map(|s| s.total).sum::<f64>() / n;
+        let total_sd: f64 = (stats
+            .iter()
+            .map(|s| (s.total - avg_total).powi(2))
+            .sum::<f64>()
+            / (n - 1.0))
+            .sqrt();
+
+        let avg_margin: f64 = stats.iter().map(|s| s.margin).sum::<f64>() / n;
+        let margin_sd: f64 = (stats
+            .iter()
+            .map(|s| (s.margin - avg_margin).powi(2))
+            .sum::<f64>()
+            / (n - 1.0))
+            .sqrt();
+
+        let ot_pct: f64 = stats.iter().filter(|s| s.is_tie).count() as f64 / n * 100.0;
+
+        let avg_pace: f64 = stats.iter().map(|s| s.pace).sum::<f64>() / n;
+        let pace_sd: f64 = (stats
+            .iter()
+            .map(|s| (s.pace - avg_pace).powi(2))
+            .sum::<f64>()
+            / (n - 1.0))
+            .sqrt();
+
+        let zero_pts_pct: f64 = stats
+            .iter()
+            .filter(|s| s.total < 0.5) // both teams scored 0
+            .count() as f64
+            / n
+            * 100.0;
+
+        println!(
+            "{:>6.2}  {:>7.1}  {:>7.1}  {:>7.1}  {:>7.1}  {:>6.1}%  {:>7.1}  {:>7.1}  {:>6.2}%",
+            d, avg_total, total_sd, avg_margin, margin_sd, ot_pct, avg_pace, pace_sd, zero_pts_pct
+        );
+    }
+
+    println!("\n(Empirical targets: NCAA tournament 2010-2024 averages, approximate)");
+
+    Ok(())
+}

--- a/crates/bracket-sim/src/bin/sim.rs
+++ b/crates/bracket-sim/src/bin/sim.rs
@@ -21,6 +21,11 @@ struct SimArgs {
     /// Number of tournament simulations to run
     #[arg(short, long, default_value_t = 10000)]
     n_sims: usize,
+
+    /// Pace dispersion ratio (variance / mean).
+    /// <1 = underdispersed (binomial), 1 = Poisson, >1 = overdispersed (NB).
+    #[arg(long, default_value_t = bracket_sim::DEFAULT_PACE_D)]
+    pace_d: f64,
 }
 
 fn main() -> io::Result<()> {
@@ -40,12 +45,13 @@ fn main() -> io::Result<()> {
     info!(
         year = args.year,
         n_sims = args.n_sims,
+        pace_d = args.pace_d,
         "starting simulation"
     );
 
     let teams = load_teams_for_year(args.input.as_deref(), args.year)?;
 
-    let mut tournament = Tournament::new();
+    let mut tournament = Tournament::new().with_pace_d(args.pace_d);
     tournament.setup_tournament(teams, &bracket_config);
     let win_probs = tournament.calculate_team_win_probabilities(args.n_sims);
 

--- a/crates/bracket-sim/src/game.rs
+++ b/crates/bracket-sim/src/game.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use rand_distr::{Distribution, Poisson};
+use rand_distr::{Binomial, Distribution, Gamma, Poisson};
 use statrs::distribution::{ContinuousCDF, Normal};
 
 use crate::{AVERAGE_PACE, AVERAGE_RATING, metrics::Metrics, team::Team};
@@ -73,28 +73,84 @@ impl Game {
         }
     }
 
-    pub fn simulate(t1_metrics: Metrics, rng: &mut impl Rng) -> GameResult {
-        let pace_poisson = Poisson::new(t1_metrics.pace).unwrap();
-        let actual_pace = pace_poisson.sample(rng);
-        Self::simulate_with_pace(t1_metrics, actual_pace, rng)
+    /// Sample a non-negative integer count with given `mean` and dispersion ratio
+    /// `d = variance / mean`.
+    ///
+    /// - `d < 1`: underdispersed → Binomial(n, p) where p = 1 - d, n = mean / p
+    /// - `d = 1`: Poisson(mean)
+    /// - `d > 1`: overdispersed → Gamma-Poisson mixture (negative binomial)
+    ///   with shape r = mean / (d - 1)
+    pub fn sample_count(mean: f64, d: f64, rng: &mut impl Rng) -> f64 {
+        if mean < 0.01 || !mean.is_finite() {
+            return 0.0;
+        }
+        let d = d.max(0.01); // clamp to avoid division by zero
+
+        if d < 1.0 {
+            // Underdispersed: Binomial(n, p) with mean = np, variance = np(1-p) = mean*d
+            // So 1-p = d, p = 1-d, n = mean/p = mean/(1-d)
+            let p = 1.0 - d;
+            let n = (mean / p).round() as u64;
+            if n == 0 {
+                return 0.0;
+            }
+            let p_actual = (mean / n as f64).clamp(0.0, 1.0);
+            match Binomial::new(n, p_actual) {
+                Ok(dist) => dist.sample(rng) as f64,
+                Err(_) => mean.round(), // fallback: deterministic
+            }
+        } else if (d - 1.0).abs() < 1e-6 {
+            match Poisson::new(mean) {
+                Ok(dist) => dist.sample(rng),
+                Err(_) => mean.round(),
+            }
+        } else {
+            // Overdispersed: Gamma-Poisson (negative binomial)
+            let r = mean / (d - 1.0);
+            let scale = mean / r;
+            let lambda = match Gamma::new(r, scale) {
+                Ok(dist) => dist.sample(rng),
+                Err(_) => return mean.round(),
+            };
+            if lambda < 0.01 {
+                return 0.0;
+            }
+            match Poisson::new(lambda) {
+                Ok(dist) => dist.sample(rng),
+                Err(_) => lambda.round(),
+            }
+        }
     }
 
-    /// Simulate with a fixed pace (no Poisson on possessions).
-    /// Used for OT where the low possession count makes Poisson a poor fit.
-    fn simulate_fixed_pace(t1_metrics: Metrics, rng: &mut impl Rng) -> GameResult {
-        Self::simulate_with_pace(t1_metrics, t1_metrics.pace, rng)
+    pub fn simulate(t1_metrics: Metrics, pace_d: f64, rng: &mut impl Rng) -> GameResult {
+        let actual_pace = Self::sample_count(t1_metrics.pace, pace_d, rng);
+        Self::simulate_with_pace(t1_metrics, actual_pace, rng)
     }
 
     fn simulate_with_pace(t1_metrics: Metrics, actual_pace: f64, rng: &mut impl Rng) -> GameResult {
         let team1_expected = t1_metrics.ortg * actual_pace / 100.0;
         let team2_expected = t1_metrics.drtg * actual_pace / 100.0;
 
-        let team1_score = Poisson::new(team1_expected).unwrap().sample(rng);
-        let team2_score = Poisson::new(team2_expected).unwrap().sample(rng);
+        let team1_score = if team1_expected < 0.01 {
+            0
+        } else {
+            match Poisson::new(team1_expected) {
+                Ok(dist) => dist.sample(rng) as u32,
+                Err(_) => team1_expected.round() as u32,
+            }
+        };
+        let team2_score = if team2_expected < 0.01 {
+            0
+        } else {
+            match Poisson::new(team2_expected) {
+                Ok(dist) => dist.sample(rng) as u32,
+                Err(_) => team2_expected.round() as u32,
+            }
+        };
 
         GameResult {
-            team1_score: team1_score as u32,
-            team2_score: team2_score as u32,
+            team1_score,
+            team2_score,
             pace: actual_pace,
         }
     }
@@ -113,7 +169,10 @@ impl Game {
 
     /// Simulate up to MAX_OT overtime periods (5 min each). Returns the winner,
     /// or None if still tied after all OT periods.
-    fn resolve_overtime(&self, tied_score: u32, rng: &mut impl Rng) -> Option<&Team> {
+    /// Uses the same pace distribution as regulation — the dispersion parameter
+    /// naturally scales variance with the mean, so low-possession OT periods
+    /// get appropriately tighter distributions without special-casing.
+    fn resolve_overtime(&self, tied_score: u32, pace_d: f64, rng: &mut impl Rng) -> Option<&Team> {
         let base_metrics = self.expected_t1_metrics();
         let ot_metrics = Metrics {
             pace: base_metrics.pace * Self::OT_MINUTES / Self::REGULATION_MINUTES,
@@ -123,7 +182,7 @@ impl Game {
         let mut t1_total = tied_score;
         let mut t2_total = tied_score;
         for _ in 0..Self::MAX_OT {
-            let ot = Game::simulate_fixed_pace(ot_metrics, rng);
+            let ot = Game::simulate(ot_metrics, pace_d, rng);
             t1_total += ot.team1_score;
             t2_total += ot.team2_score;
             if let Some(w) = self.pick_by_score(t1_total, t2_total) {
@@ -133,11 +192,11 @@ impl Game {
         None
     }
 
-    pub fn winner(&self, rng: &mut impl Rng) -> Option<&Team> {
+    pub fn winner(&self, pace_d: f64, rng: &mut impl Rng) -> Option<&Team> {
         let result = self.result.as_ref()?;
 
         self.pick_by_score(result.team1_score, result.team2_score)
-            .or_else(|| self.resolve_overtime(result.team1_score, rng))
+            .or_else(|| self.resolve_overtime(result.team1_score, pace_d, rng))
             .or_else(|| {
                 // Coin flip after MAX_OT
                 if rng.random::<bool>() {
@@ -152,6 +211,7 @@ impl Game {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DEFAULT_PACE_D;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
@@ -175,7 +235,7 @@ mod tests {
     fn winner_returns_none_without_result() {
         let game = make_equal_game();
         let mut rng = StdRng::seed_from_u64(0);
-        assert!(game.winner(&mut rng).is_none());
+        assert!(game.winner(DEFAULT_PACE_D, &mut rng).is_none());
     }
 
     #[test]
@@ -187,14 +247,14 @@ mod tests {
             pace: 68.0,
         });
         let mut rng = StdRng::seed_from_u64(0);
-        assert_eq!(game.winner(&mut rng).unwrap().team, "Team1");
+        assert_eq!(game.winner(DEFAULT_PACE_D, &mut rng).unwrap().team, "Team1");
 
         game.result = Some(GameResult {
             team1_score: 70,
             team2_score: 80,
             pace: 68.0,
         });
-        assert_eq!(game.winner(&mut rng).unwrap().team, "Team2");
+        assert_eq!(game.winner(DEFAULT_PACE_D, &mut rng).unwrap().team, "Team2");
     }
 
     #[test]
@@ -214,7 +274,7 @@ mod tests {
                 team2_score: 75,
                 pace: 68.0,
             });
-            let winner = game.winner(&mut rng).unwrap();
+            let winner = game.winner(DEFAULT_PACE_D, &mut rng).unwrap();
             if winner.team == "Team1" {
                 t1_wins += 1;
             } else {
@@ -246,7 +306,7 @@ mod tests {
                 team2_score: 75,
                 pace: 68.0,
             });
-            if game.winner(&mut rng).unwrap().team == "Favorite" {
+            if game.winner(DEFAULT_PACE_D, &mut rng).unwrap().team == "Favorite" {
                 fav_wins += 1;
             }
         }
@@ -255,6 +315,124 @@ mod tests {
             fav_wins > 600,
             "Favorite should win most OTs, got {}/1000",
             fav_wins
+        );
+    }
+
+    #[test]
+    fn sample_count_underdispersed() {
+        let mut rng = StdRng::seed_from_u64(123);
+        let mean = 68.0;
+        let d = 0.5; // underdispersed: variance = 0.5 * mean = 34
+        let n = 10_000;
+
+        let samples: Vec<f64> = (0..n)
+            .map(|_| Game::sample_count(mean, d, &mut rng))
+            .collect();
+        let sample_mean: f64 = samples.iter().sum::<f64>() / n as f64;
+        let sample_var: f64 = samples
+            .iter()
+            .map(|x| (x - sample_mean).powi(2))
+            .sum::<f64>()
+            / (n - 1) as f64;
+
+        // Variance should be roughly mean * d = 34 (less than Poisson's 68)
+        assert!(
+            sample_var < mean * 0.8,
+            "Underdispersed variance ({:.1}) should be well below Poisson ({:.1})",
+            sample_var,
+            mean
+        );
+        assert!(
+            (sample_mean - mean).abs() < 2.0,
+            "Mean ({:.1}) should be close to target ({:.1})",
+            sample_mean,
+            mean
+        );
+    }
+
+    #[test]
+    fn sample_count_overdispersed() {
+        let mut rng = StdRng::seed_from_u64(123);
+        let mean = 68.0;
+        let d = 1.68; // overdispersed: variance = 1.68 * mean ≈ 114
+        let n = 10_000;
+
+        let samples: Vec<f64> = (0..n)
+            .map(|_| Game::sample_count(mean, d, &mut rng))
+            .collect();
+        let sample_mean: f64 = samples.iter().sum::<f64>() / n as f64;
+        let sample_var: f64 = samples
+            .iter()
+            .map(|x| (x - sample_mean).powi(2))
+            .sum::<f64>()
+            / (n - 1) as f64;
+
+        assert!(
+            sample_var > mean * 1.2,
+            "Overdispersed variance ({:.1}) should exceed Poisson ({:.1})",
+            sample_var,
+            mean
+        );
+        assert!(
+            (sample_mean - mean).abs() < 2.0,
+            "Mean ({:.1}) should be close to target ({:.1})",
+            sample_mean,
+            mean
+        );
+    }
+
+    #[test]
+    fn sample_count_poisson_baseline() {
+        let mut rng = StdRng::seed_from_u64(123);
+        let mean = 68.0;
+        let d = 1.0; // Poisson
+        let n = 10_000;
+
+        let samples: Vec<f64> = (0..n)
+            .map(|_| Game::sample_count(mean, d, &mut rng))
+            .collect();
+        let sample_mean: f64 = samples.iter().sum::<f64>() / n as f64;
+        let sample_var: f64 = samples
+            .iter()
+            .map(|x| (x - sample_mean).powi(2))
+            .sum::<f64>()
+            / (n - 1) as f64;
+
+        // Poisson: variance ≈ mean
+        assert!(
+            (sample_var - mean).abs() < mean * 0.1,
+            "Poisson variance ({:.1}) should be close to mean ({:.1})",
+            sample_var,
+            mean
+        );
+    }
+
+    #[test]
+    fn ot_has_pace_variance() {
+        let t1 = make_team("Team1", 1, 105.0, 105.0, 68.0);
+        let t2 = make_team("Team2", 16, 105.0, 105.0, 68.0);
+        let game = Game::new(t1, t2);
+        let base_metrics = game.expected_t1_metrics();
+        let ot_metrics = Metrics {
+            pace: base_metrics.pace * Game::OT_MINUTES / Game::REGULATION_MINUTES,
+            ..base_metrics
+        };
+
+        let mut rng = StdRng::seed_from_u64(456);
+        let n = 1000;
+        let paces: Vec<f64> = (0..n)
+            .map(|_| Game::simulate(ot_metrics, DEFAULT_PACE_D, &mut rng).pace)
+            .collect();
+
+        let pace_mean: f64 = paces.iter().sum::<f64>() / n as f64;
+        let pace_var: f64 =
+            paces.iter().map(|x| (x - pace_mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+
+        // OT pace is ~8.5 possessions — should have some variance
+        assert!(
+            pace_var > 1.0,
+            "OT pace should have variance > 1, got {:.2}",
+            pace_var
         );
     }
 }

--- a/crates/bracket-sim/src/lib.rs
+++ b/crates/bracket-sim/src/lib.rs
@@ -48,6 +48,16 @@ pub const MIN_RTG: f64 = 75.0;
 
 pub const UPDATE_FACTOR: f64 = 0.05;
 
+/// Default pace dispersion ratio (variance / mean) for possession count sampling.
+/// - d < 1: underdispersed (binomial) — tighter than Poisson
+/// - d = 1: Poisson
+/// - d > 1: overdispersed (negative binomial) — wider than Poisson
+///
+/// Calibrated to d=0.3 via score-dist sweep against NCAA tournament empirical
+/// targets (~142 avg total, ~19 total stddev, ~6% OT). At d=0.3 total stddev ≈ 20,
+/// closest to the empirical ~19. See issue #48 for further calibration notes.
+pub const DEFAULT_PACE_D: f64 = 0.3;
+
 /// Returns the `data/` directory at the workspace root.
 /// Works because `CARGO_MANIFEST_DIR` is `crates/bracket-sim/` — two levels up.
 pub fn data_dir() -> std::path::PathBuf {

--- a/crates/bracket-sim/src/tournament.rs
+++ b/crates/bracket-sim/src/tournament.rs
@@ -4,7 +4,7 @@ use crate::bracket_config::{BRACKET_SEED_ORDER, BracketConfig};
 use crate::game::Game;
 use crate::metrics::Metrics;
 use crate::team::Team;
-use crate::{Bracket, ScoringSystem};
+use crate::{Bracket, DEFAULT_PACE_D, ScoringSystem};
 use std::collections::HashMap;
 use std::io;
 
@@ -13,6 +13,8 @@ pub struct Tournament {
     teams: Vec<Team>,
     games: Vec<Game>,
     seeds: HashMap<String, u8>,
+    /// Pace dispersion ratio (variance / mean). See [`DEFAULT_PACE_D`].
+    pace_d: f64,
 }
 
 impl Default for Tournament {
@@ -27,7 +29,14 @@ impl Tournament {
             teams: Vec::new(),
             games: Vec::new(),
             seeds: HashMap::new(),
+            pace_d: DEFAULT_PACE_D,
         }
+    }
+
+    /// Set the pace dispersion ratio. See [`DEFAULT_PACE_D`] for details.
+    pub fn with_pace_d(mut self, pace_d: f64) -> Self {
+        self.pace_d = pace_d;
+        self
     }
 
     pub fn setup_tournament(&mut self, teams: Vec<Team>, config: &BracketConfig) {
@@ -141,9 +150,9 @@ impl Tournament {
 
         for mut game in games {
             let t1_expected = game.expected_t1_metrics();
-            game.result = Some(Game::simulate(t1_expected, rng));
+            game.result = Some(Game::simulate(t1_expected, self.pace_d, rng));
 
-            if let Some(winner) = game.winner(rng) {
+            if let Some(winner) = game.winner(self.pace_d, rng) {
                 let result = game.result.as_ref().unwrap();
                 let winner_is_t1 = winner.team == game.team1.team;
 
@@ -345,7 +354,7 @@ impl Tournament {
     }
 
     /// Simulate the tournament, returning results as a ByteBracket u64.
-    /// Same Poisson simulation + Bayesian metric updates as `simulate_tournament`,
+    /// Same NB/Poisson simulation + Bayesian metric updates as `simulate_tournament`,
     /// but sets bits instead of collecting string pairs.
     pub fn simulate_tournament_bb(&mut self, rng: &mut impl Rng) -> u64 {
         let mut bits: u64 = 0;
@@ -357,9 +366,9 @@ impl Tournament {
 
             for mut game in current_round_games {
                 let t1_expected = game.expected_t1_metrics();
-                game.result = Some(Game::simulate(t1_expected, rng));
+                game.result = Some(Game::simulate(t1_expected, self.pace_d, rng));
 
-                if let Some(winner) = game.winner(rng) {
+                if let Some(winner) = game.winner(self.pace_d, rng) {
                     let result = game.result.as_ref().unwrap();
                     let winner_is_t1 = winner.team == game.team1.team;
 

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,16 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Sim: configurable pace dispersion + score-dist calibration tool (closes #41)
+- **Generalized pace distribution** in `crates/bracket-sim/src/game.rs` via `Game::sample_count(mean, d)` — a single dispersion ratio `d = variance/mean` controls the distribution family: d<1 uses binomial (underdispersed), d=1 uses Poisson, d>1 uses Gamma-Poisson/NB (overdispersed).
+- **Unified regulation and OT paths** — overtime now uses the same pace distribution as regulation instead of the old fixed-pace workaround. The dispersion parameter naturally scales variance with the mean.
+- **Calibrated default `DEFAULT_PACE_D = 0.3`** (underdispersed) via score-dist sweep against NCAA tournament empirical targets. At d=0.3 the simulated total-score stddev ≈ 20, closest to the empirical ~19.
+- **Panic-free simulation** — all distribution constructors use `match` with deterministic fallbacks instead of `unwrap()`. No panics possible in `sample_count` or `simulate_with_pace`.
+- **New CLI binary `score-dist`** — sweeps pace dispersion values and reports game-level statistics (avg total, margin spread, OT frequency, pace stddev) for calibration against empirical data.
+- **New CLI flag `--pace-d`** on `sim` binary — overrides the default dispersion ratio.
+- **Threaded `pace_d`** through `Tournament` (new field + `with_pace_d()` builder) → `Game::simulate()` → `Game::winner()` → `resolve_overtime()`.
+- **New tests**: `sample_count_underdispersed`, `sample_count_overdispersed`, `sample_count_poisson_baseline`, `ot_has_pace_variance`.
+
 ### 2026-03-15 — Pipeline orchestration scripts
 - **New script** `scripts/refresh.sh` — runs the full KenPom/Kalshi ingestion pipeline (scrape KenPom, fetch raw Kalshi futures, fit anchor model, normalize Kalshi futures, calibrate goose values). Supports `--hours N` flag to control cache TTL (default 6 hours).
 - **CI: Python checks** — added `run_python` section to `scripts/ci.sh`: verifies `uv` deps install (`uv sync --frozen`) and runs `scrape_kenpom.py --help` as a smoke test. Wired into `all` and available as `./scripts/ci.sh python`.

--- a/docs/prompts/cdai__sim-negative-binom/1741996800-tackle-issue-41.txt
+++ b/docs/prompts/cdai__sim-negative-binom/1741996800-tackle-issue-41.txt
@@ -1,0 +1,3 @@
+your job is to tackle an issue on github. note that there is a branch called cdai__stray-prompts. you should pop off the prompt that created this issue and include it when you go through your checklist of including all the prompts (but include it on this branch, not the folder it's in currently). when you're done, go through the /checklist and submit a PR
+
+the issue you will take is #41; the stray prompt is docs/prompts/cdai__add-bracket-sim/1742058001-sim-negative-binomial.txt

--- a/docs/prompts/cdai__sim-negative-binom/1741996900-update-pr-no-panic-issue.txt
+++ b/docs/prompts/cdai__sim-negative-binom/1741996900-update-pr-no-panic-issue.txt
@@ -1,0 +1,5 @@
+yes update the PR. only thing you might want to do is prevent panicking on zero draws -- it shouldnt happen any more, but in that edge case we should either re-sample or eject to coinflip. i just want this part of the code to be panick-free.
+
+and it depends on how you're getting your data. our initial bracket here has say the top 1-64 teams... is your dataset over all ncaa games? we might have a mismatch somewhere
+
+i guess total being too high is interesting... so what i would do is make an issue with all of the observations you made, how you got the data, any updates re: the questions i asked you

--- a/docs/prompts/cdai__sim-negative-binom/1742058001-sim-negative-binomial.txt
+++ b/docs/prompts/cdai__sim-negative-binom/1742058001-sim-negative-binomial.txt
@@ -1,0 +1,1 @@
+put up another issue: make the sim use something smarter than poisson distributions, especially for # of possessions count. i am guessing we can fit something like a negative binomial to the variance of the pace data and we'd get something that behaves much better than our current poisson if we were using it for overtime.


### PR DESCRIPTION
## Summary
- Generalize pace sampling with a dispersion ratio `d = variance/mean`: d<1 binomial (underdispersed), d=1 Poisson, d>1 NB (overdispersed)
- Calibrate `DEFAULT_PACE_D = 0.3` via score-dist sweep — total stddev ≈ 20, closest to empirical ~19
- Unify regulation and OT paths (OT no longer uses fixed-pace workaround)
- Make all distribution constructors panic-free with deterministic fallbacks
- Add `score-dist` binary for calibration sweeps and `--pace-d` CLI flag on `sim`

Closes #41. Follow-up calibration observations filed in #48 (total too high, OT% too low, data source questions).

## Test plan
- [x] 30 tests pass including new `sample_count_underdispersed`, `sample_count_overdispersed`, `sample_count_poisson_baseline`, `ot_has_pace_variance`
- [x] `./scripts/ci.sh crates` passes (build, test, fmt, clippy)
- [x] `score-dist` binary runs successfully with calibration sweep
- [x] Existing OT tests (tie-breaking fairness, stronger-team-favored) still pass