### PR TITLE
Export scoring and metrics modules publicly from bracket-sim

### DIFF
--- a/crates/bracket-sim/src/lib.rs
+++ b/crates/bracket-sim/src/lib.rs
@@ -5,8 +5,8 @@ mod bracket;
 pub mod bracket_config;
 pub mod calibration;
 mod game;
-mod metrics;
-mod scoring;
+pub mod metrics;
+pub mod scoring;
 pub mod team;
 mod tournament;
 


### PR DESCRIPTION
## Summary
- Make `scoring` and `metrics` modules `pub` in `bracket-sim` so downstream crates (e.g., `brackets`) can access `scoring::score_base_bb` and `metrics::Metrics` directly.

## Test plan
- [x] `cargo check -p bracket-sim` passes with no errors
- Downstream consumer (`brackets` repo) can now import `bracket_sim::scoring::score_base_bb` and `bracket_sim::metrics::Metrics`