### PR TITLE
Make score_base_bb public for downstream consumers

### DIFF
--- a/crates/bracket-sim/src/scoring.rs
+++ b/crates/bracket-sim/src/scoring.rs
@@ -22,8 +22,7 @@ pub enum ScoringSystem {
 /// earlier-round disagreements.
 ///
 /// Returns total points under Base scoring (1, 2, 4, 8, 16, 32 per round).
-#[cfg(test)]
-pub(crate) fn score_base_bb(bracket: u64, results: u64) -> u32 {
+pub fn score_base_bb(bracket: u64, results: u64) -> u32 {
     let matching = !(bracket ^ results); // bit i set iff bracket[i] == results[i]
 
     // Round 0 (bits 0-31): no feeder check needed

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Make `score_base_bb` public in bracket-sim
+- Removed `#[cfg(test)]` and `pub(crate)` gate from `scoring::score_base_bb` so downstream consumers (e.g. the brackets pool-strategy repo) can use it directly instead of duplicating the function.
+
 ### 2026-03-15 — Sim: configurable pace dispersion + score-dist calibration tool (closes #41)
 - **Generalized pace distribution** in `crates/bracket-sim/src/game.rs` via `Game::sample_count(mean, d)` — a single dispersion ratio `d = variance/mean` controls the distribution family: d<1 uses binomial (underdispersed), d=1 uses Poisson, d>1 uses Gamma-Poisson/NB (overdispersed).
 - **Unified regulation and OT paths** — overtime now uses the same pace distribution as regulation instead of the old fixed-pace workaround. The dispersion parameter naturally scales variance with the mean.

--- a/docs/prompts/cdai__export-score-base-bb/1742076000-export-score-base-bb.txt
+++ b/docs/prompts/cdai__export-score-base-bb/1742076000-export-score-base-bb.txt
@@ -1,0 +1,1 @@
+Make score_base_bb public in bracket-sim's scoring module. It's currently #[cfg(test)] pub(crate) but downstream consumers need it for ByteBracket scoring in equity simulations.


### PR DESCRIPTION
## Summary
- Remove `#[cfg(test)]` and `pub(crate)` gate from `scoring::score_base_bb` so downstream crates can use `bracket_sim::scoring::score_base_bb` directly

## Why
The brackets pool-strategy repo needs this function for ByteBracket scoring in equity simulations. Without it being public, they have to duplicate the entire function locally.

## Test plan
- [x] `cargo check -p bracket-sim` passes
- [x] `cargo +nightly fmt --all --check` passes
- [x] `cargo clippy -p bracket-sim` passes