### PR TITLE
Upgrade sfoundry to nightly-94eb5fc (closes #15)

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -1,0 +1,5 @@
+{
+  "lib/forge-std": {
+    "rev": "3e6d5cd6dd0dbe61952e6075ea6d55ed31d26381"
+  }
+}

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Upgrade seismic foundry to nightly-94eb5fc (closes #15)
+- Updated `sfoundry` pin in `mise.toml` from `nightly-08913bcc...` to `nightly-94eb5fc1...` (2026-03-14 release).
+
 ### 2026-03-15 — Make `score_base_bb` public in bracket-sim
 - Removed `#[cfg(test)]` and `pub(crate)` gate from `scoring::score_base_bb` so downstream consumers (e.g. the brackets pool-strategy repo) can use it directly instead of duplicating the function.
 

--- a/docs/prompts/cdai__sfoundry-new/1742036400-upgrade-sfoundry.txt
+++ b/docs/prompts/cdai__sfoundry-new/1742036400-upgrade-sfoundry.txt
@@ -1,0 +1,5 @@
+your job is to tackle an issue on github. note that there is a branch called cdai__stray-prompts. you should pop off the prompt that created this
+  issue and include it when you go through your checklist of including all the prompts (but include it on this branch, not the folder it's in
+  currently). when you're done, go through the /checklist and submit a PR
+
+issue 15

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 # Downloads nightly release: https://github.com/SeismicSystems/seismic-foundry/releases
 # Contains sforge, sanvil, scast, schisel — all added to PATH.
 # Pin updated from samlaf's seismic repo. Run `mise install` to get latest.
-sfoundry = "nightly-08913bcc240efcb17dcee38e60adfa482b4bcd44"
+sfoundry = "nightly-94eb5fc14e4797b6436ba000d0dbcfe8d2318b57"
 
 # Downloads ssolc release: https://github.com/SeismicSystems/seismic-solidity/releases
 ssolc = { version = "2ebb36d", bin = "ssolc" }


### PR DESCRIPTION
## Summary
- Updated `sfoundry` pin in `mise.toml` from `nightly-08913bcc240efcb17dcee38e60adfa482b4bcd44` to `nightly-94eb5fc14e4797b6436ba000d0dbcfe8d2318b57` (2026-03-14 release)
- Updated `contracts/foundry.lock` (forge-std dependency resolution from new sfoundry)

## Test plan
- [x] `mise install` succeeds with new pin
- [x] `sforge --version` / `sanvil --version` report new build (commit 572fe1c, 2026-03-14)
- [x] `./scripts/ci.sh` — contracts build/test/fmt all pass; crates build/test/fmt/clippy all pass; python passes
- [x] Pre-existing packages typecheck failure (TS2742 wagmi type inference) — not introduced by this change