### PR TITLE
Improve desktop bracket vertical symmetry (closes #31)

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,11 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-15 — Improve desktop bracket vertical symmetry (closes #31)
+- Replaced hardcoded pixel spacing (`getVerticalSpacing`) with flex-based layout using `justify-around` and `items-stretch`. Each round column now stretches to the same height as the R64 column, and games within each round automatically center between their two feeder games from the previous round.
+- Top and bottom halves now use `items-stretch` for equal-height regions, producing a symmetric layout where the Final Four sits cleanly in the center.
+- Added `gap-2` minimum spacing between games for visual breathing room.
+
 ### 2026-03-15 — Upgrade seismic foundry to nightly-94eb5fc (closes #15)
 - Updated `sfoundry` pin in `mise.toml` from `nightly-08913bcc...` to `nightly-94eb5fc1...` (2026-03-14 release).
 

--- a/docs/prompts/cdai__veritical-sym/1742054400-vertical-symmetry.txt
+++ b/docs/prompts/cdai__veritical-sym/1742054400-vertical-symmetry.txt
@@ -1,0 +1,7 @@
+your job is to tackle an issue on github. note that there is a branch called cdai__stray-prompts. you should pop off the prompt that created this
+  issue and include it when you go through your checklist of including all the prompts (but include it on this branch, not the folder it's in
+  currently). when you're done, go through the /checklist and submit a PR
+
+there's no stray-prompt for this one, i think
+
+issue #31

--- a/packages/web/src/components/BracketRegion.tsx
+++ b/packages/web/src/components/BracketRegion.tsx
@@ -29,39 +29,36 @@ export function BracketRegion({
   const orderedRounds = reversed ? [...rounds].reverse() : rounds;
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col flex-1">
       <h3 className={`text-sm font-semibold text-accent uppercase tracking-wider mb-3 px-1 ${reversed ? "text-right" : ""}`}>
         {regionName}
       </h3>
-      <div className="flex flex-row items-center gap-1">
+      <div className="flex flex-row items-stretch gap-1 flex-1">
         {orderedRounds.map((roundGames, displayIdx) => {
           const actualRoundIdx = reversed
             ? rounds.length - 1 - displayIdx
             : displayIdx;
-          const roundSpacing = getVerticalSpacing(actualRoundIdx, compact);
 
           return (
-            <div
-              key={displayIdx}
-              className="flex flex-col"
-              style={{ gap: `${roundSpacing}px` }}
-            >
+            <div key={displayIdx} className="flex flex-col">
               <div className="text-[10px] text-text-muted text-center mb-1 whitespace-nowrap">
                 {ROUND_NAMES[actualRoundIdx]}
               </div>
-              {roundGames.map((game) => (
-                <BracketGame
-                  key={game.gameIndex}
-                  team1={game.team1}
-                  team2={game.team2}
-                  winner={game.winner}
-                  onPick={(pickTeam1) => onPick(game.gameIndex, pickTeam1)}
-                  disabled={disabled}
-                  compact={actualRoundIdx === 0}
-                  mobile={compact}
-                  gameStatus={tournamentStatus?.games[game.gameIndex]}
-                />
-              ))}
+              <div className="flex flex-col flex-1 justify-around gap-2">
+                {roundGames.map((game) => (
+                  <BracketGame
+                    key={game.gameIndex}
+                    team1={game.team1}
+                    team2={game.team2}
+                    winner={game.winner}
+                    onPick={(pickTeam1) => onPick(game.gameIndex, pickTeam1)}
+                    disabled={disabled}
+                    compact={actualRoundIdx === 0}
+                    mobile={compact}
+                    gameStatus={tournamentStatus?.games[game.gameIndex]}
+                  />
+                ))}
+              </div>
             </div>
           );
         })}
@@ -70,22 +67,3 @@ export function BracketRegion({
   );
 }
 
-function getVerticalSpacing(round: number, compact: boolean): number {
-  if (compact) {
-    // Scaled-down spacing for mobile
-    switch (round) {
-      case 0: return 6;
-      case 1: return 22;
-      case 2: return 56;
-      case 3: return 124;
-      default: return 6;
-    }
-  }
-  switch (round) {
-    case 0: return 8;
-    case 1: return 32;
-    case 2: return 86;
-    case 3: return 194;
-    default: return 8;
-  }
-}

--- a/packages/web/src/components/BracketView.tsx
+++ b/packages/web/src/components/BracketView.tsx
@@ -69,7 +69,7 @@ export function BracketView({
     <div className="overflow-x-auto pb-4">
       <div className="flex flex-col gap-12 min-w-[1400px]">
         {/* Top half: East (left) + Final Four + West (right) */}
-        <div className="flex items-start justify-center gap-4">
+        <div className="flex items-stretch justify-center gap-4">
           <BracketRegion
             regionName={regions[0]}
             rounds={getRegionGames(0)}
@@ -96,7 +96,7 @@ export function BracketView({
         </div>
 
         {/* Bottom half: South (left) + spacer + Midwest (right) */}
-        <div className="flex items-start justify-center gap-4">
+        <div className="flex items-stretch justify-center gap-4">
           <BracketRegion
             regionName={regions[2]}
             rounds={getRegionGames(2)}

--- a/packages/web/src/components/FinalFour.tsx
+++ b/packages/web/src/components/FinalFour.tsx
@@ -26,7 +26,7 @@ export function FinalFour({
         Final Four
       </h3>
 
-      <div className="flex flex-col items-center gap-8">
+      <div className="flex flex-col items-center justify-center gap-8 flex-1">
         {/* Semifinal 1 */}
         {semifinal1 && (
           <BracketGame


### PR DESCRIPTION
## Summary
- Replaced hardcoded pixel spacing (`getVerticalSpacing` with values 8/32/86/194px) with flex-based layout using `justify-around` and `items-stretch`. Each round column now stretches to the same height as the R64 column, and games within each round automatically center between their two feeder games from the previous round.
- Top and bottom halves use `items-stretch` for equal-height regions, producing a symmetric layout where the Final Four sits cleanly in the center.
- Added `gap-2` minimum spacing between games for visual breathing room.

## Test plan
- [ ] Run `bun p:pre` and verify desktop bracket layout: games in R32/S16/E8 should be vertically centered between their feeder games
- [ ] Check that top half (East + Final Four + West) and bottom half (South + spacer + Midwest) have equal height
- [ ] Verify mobile tabbed view is unaffected
- [ ] Run `bun p:post` and verify layout with filled brackets + tournament overlays