### PR TITLE
Store bracket picks as hex in localStorage

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,12 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Store bracket picks as hex in localStorage (closes #64)
+- **Changed** `loadPicks` / `savePicks` in `packages/web/src/hooks/useBracket.ts` to use compact storage formats instead of JSON boolean arrays (~300+ chars).
+- **Complete brackets** stored as canonical bytes8 hex string (18 chars, e.g. `0x8000000000000000`), using `encodeBracket` / `validateBracket` from the client library.
+- **Partial brackets** stored as `"partial:"` + 63-char string of `1`/`0`/`-` (71 chars total), preserving in-progress picks across page refreshes.
+- No migration needed — no real users yet; old JSON format is silently discarded on load.
+
 ### 2026-03-15 — Restructure data directory + centralized name mappings + First Four handling
 - **Data directory restructure**: Moved from `data/{year}/` to `data/{year}/men/` and `data/{year}/women/`. All per-gender data (tournament.json, kenpom.csv, status.json, mappings/) now lives under a gender subdirectory. Renamed `tournament-status.json` → `status.json`. Updated all CLI defaults, path helpers, frontend imports, and test references.
 - **New file** `data/mappings.toml` — centralized name mapping from sources (KenPom, Kalshi) to NCAA canonical names. Single source of truth for team name normalization.

--- a/docs/prompts/cdai__hex-localstorage/1742083200-hex-localstorage.txt
+++ b/docs/prompts/cdai__hex-localstorage/1742083200-hex-localstorage.txt
@@ -1,0 +1,1 @@
+Spawn parallel agents to solve each of these issues. they should all make PRs targeting main: https://github.com/SeismicSystems/march-madness/issues/64

--- a/packages/web/src/hooks/useBracket.ts
+++ b/packages/web/src/hooks/useBracket.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { encodeBracket } from "@march-madness/client";
+import { encodeBracket, validateBracket } from "@march-madness/client";
 
 import { getAllTeamsInBracketOrder, type Team } from "../lib/tournament";
 
@@ -22,20 +22,61 @@ const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
 const STORAGE_PREFIX = "mm-picks-";
 const storageKey = (addr: string) => `${STORAGE_PREFIX}${addr.toLowerCase()}`;
 
+/** Sentinel prefix for incomplete (partial) brackets in localStorage. */
+const PARTIAL_PREFIX = "partial:";
+
+/**
+ * Load picks from localStorage. Supports two formats:
+ * - Complete bracket: canonical bytes8 hex string (e.g. "0x8000000000000000")
+ * - Partial bracket: "partial:" + 63-char string of '1', '0', or '-' (no pick)
+ */
 function loadPicks(addr: string): (boolean | null)[] | null {
   try {
     const raw = localStorage.getItem(storageKey(addr));
     if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed) && parsed.length === 63) return parsed;
+
+    // Complete bracket: canonical bytes8 hex
+    if (validateBracket(raw)) {
+      const bits = BigInt(raw as `0x${string}`);
+      const picks: (boolean | null)[] = [];
+      for (let i = 0; i < 63; i++) {
+        picks.push(((bits >> BigInt(62 - i)) & BigInt(1)) === BigInt(1));
+      }
+      return picks;
+    }
+
+    // Partial bracket: "partial:" + 63-char pick string
+    if (raw.startsWith(PARTIAL_PREFIX)) {
+      const pickStr = raw.slice(PARTIAL_PREFIX.length);
+      if (pickStr.length !== 63) return null;
+      const picks: (boolean | null)[] = [];
+      for (const ch of pickStr) {
+        if (ch === "1") picks.push(true);
+        else if (ch === "0") picks.push(false);
+        else picks.push(null);
+      }
+      return picks;
+    }
   } catch {
     // corrupt data
   }
   return null;
 }
 
+/**
+ * Save picks to localStorage. Complete brackets are stored as canonical
+ * bytes8 hex (18 chars). Incomplete brackets use a compact "partial:..."
+ * format (71 chars) instead of the old JSON boolean array (~300+ chars).
+ */
 function savePicks(addr: string, picks: (boolean | null)[]) {
-  localStorage.setItem(storageKey(addr), JSON.stringify(picks));
+  const isComplete = picks.every((p) => p !== null);
+  if (isComplete) {
+    const hex = encodeBracket(picks as boolean[]);
+    localStorage.setItem(storageKey(addr), hex);
+  } else {
+    const pickStr = picks.map((p) => (p === true ? "1" : p === false ? "0" : "-")).join("");
+    localStorage.setItem(storageKey(addr), PARTIAL_PREFIX + pickStr);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace JSON boolean array storage (~300+ chars) with compact formats in `loadPicks`/`savePicks`
- Complete brackets stored as canonical bytes8 hex string (18 chars) using `encodeBracket`/`validateBracket` from client library
- Partial (in-progress) brackets stored as `"partial:"` + 63-char string of `1`/`0`/`-` (71 chars total)
- No migration needed — old JSON format is silently discarded on load (no real users yet)

Closes #64

## Test plan
- [x] CI passes (typecheck, lint, build, test — all 14 checks green)
- [ ] Manual: fill in partial bracket, refresh page, verify picks persist
- [ ] Manual: complete all 63 picks, check localStorage shows hex string (18 chars)
- [ ] Manual: partially fill bracket, check localStorage shows `partial:...` format
- [ ] Manual: login migration (zero-address picks migrate to real address) still works