### PR TITLE
Add refresh-ratings.sh convenience script

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Refresh ratings wrapper script
+- **New script** `scripts/refresh-ratings.sh` — convenience wrapper that scrapes KenPom ratings then runs Kalshi calibration in sequence. Defaults to 2-hour Kalshi cache TTL. Flags: `--cache-ttl` (seconds), `--no-kalshi` (kenpom only), `--no-kenpom` (calibrate only). Everything after `--` passes through to the calibrate binary. Step indicators `[1/2]`/`[2/2]` show progress; kenpom failure aborts before calibration.
+
 ### 2026-03-16 — Unsquish First Four teams in KenPom CSV
 - **Data**: `data/2026/men/kenpom.csv` now has one row per team (68 rows) instead of squishing First Four pairs into single rows with averaged metrics. Re-scraped from KenPom to get real individual ratings.
 - **Calibration**: New `save_kenpom_csv_with_goose()` in `bracket-sim/src/team.rs` preserves individual team metrics when writing calibrated goose values. For First Four teams, the slot's calibrated goose is applied to both individual team rows.

--- a/docs/prompts/cdai__refresh-ratings-script/1742148000-refresh-ratings-script.txt
+++ b/docs/prompts/cdai__refresh-ratings-script/1742148000-refresh-ratings-script.txt
@@ -1,0 +1,15 @@
+hey can you write a ./scripts/FILE.sh that lets me run the kenpom update and then run the kalshi calibrator? ideally the command would let me pass thru kalshi ttl as well, and it should default to say 2 hours.
+
+basically this is a workflow i will run a lot so i want a nice wrapper script for it
+
+---
+
+also make sure that if kenpom fails, we fail in our wrapper script. it should also say what step i'm on
+
+and also you should let me pass thru calibrate args
+
+(i feel like it makes no sense to put in a different year to this script, remove that option)
+
+---
+
+don't call it --bracket-only... call it --kenpom-only or --no-kalshi

--- a/scripts/refresh-ratings.sh
+++ b/scripts/refresh-ratings.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scrape fresh KenPom ratings and then run Kalshi calibration to update goose values.
+#
+# Usage:
+#   ./scripts/refresh-ratings.sh                       # scrape + calibrate (2h cache TTL)
+#   ./scripts/refresh-ratings.sh --cache-ttl 3600      # custom Kalshi cache TTL (seconds)
+#   ./scripts/refresh-ratings.sh --no-kalshi           # scrape kenpom only, skip calibration
+#   ./scripts/refresh-ratings.sh --no-kenpom           # calibrate only, skip kenpom scrape
+#   ./scripts/refresh-ratings.sh -- --max-iter 200     # pass extra flags to calibrator
+#
+# Everything after "--" is forwarded to the calibrate binary.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CACHE_TTL="7200"  # 2 hours
+RUN_KENPOM=true
+RUN_KALSHI=true
+CALIBRATE_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cache-ttl)
+      CACHE_TTL="$2"
+      shift 2
+      ;;
+    --no-kalshi)
+      RUN_KALSHI=false
+      shift
+      ;;
+    --no-kenpom)
+      RUN_KENPOM=false
+      shift
+      ;;
+    --)
+      shift
+      CALIBRATE_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--cache-ttl SECONDS] [--no-kalshi] [--no-kenpom] [-- CALIBRATE_ARGS...]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Step 1/2: Scrape KenPom ─────────────────────────────────
+if [[ "$RUN_KENPOM" == true ]]; then
+  echo "[1/2] Scraping KenPom ratings..."
+  if ! uv run scripts/scrape_kenpom.py --bracket-only; then
+    echo "FAILED: KenPom scrape failed, aborting." >&2
+    exit 1
+  fi
+  echo "      Wrote data/2026/men/kenpom.csv"
+else
+  echo "[1/2] Skipping KenPom scrape (--no-kenpom)"
+fi
+
+# ── Step 2/2: Kalshi calibration ────────────────────────────
+if [[ "$RUN_KALSHI" == true ]]; then
+  echo "[2/2] Running Kalshi calibration (cache-ttl=${CACHE_TTL}s)..."
+  cargo run --release -p bracket-sim --bin calibrate -- \
+    --cache-ttl "$CACHE_TTL" \
+    "${CALIBRATE_ARGS[@]+"${CALIBRATE_ARGS[@]}"}"
+  echo "      Calibrated ratings saved to data/2026/men/kenpom.csv"
+else
+  echo "[2/2] Skipping Kalshi calibration (--no-kalshi)"
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary
- New `scripts/refresh-ratings.sh` — wrapper that runs KenPom scrape then Kalshi calibration in sequence
- Defaults to 2-hour Kalshi cache TTL (`--cache-ttl` to override)
- `--no-kalshi` / `--no-kenpom` to skip either step
- Everything after `--` passes through to the calibrate binary (e.g. `-- --max-iter 200`)
- Step indicators `[1/2]`/`[2/2]` and early abort on kenpom failure

## Test plan
- [ ] `./scripts/refresh-ratings.sh --no-kalshi` runs kenpom only
- [ ] `./scripts/refresh-ratings.sh --no-kenpom` runs calibration only
- [ ] `./scripts/refresh-ratings.sh` runs both in sequence
- [ ] Unknown flags produce usage error