### PR TITLE
Filter Kalshi calibration to tournament teams only

### DIFF
--- a/crates/bracket-sim/src/bin/calibrate.rs
+++ b/crates/bracket-sim/src/bin/calibrate.rs
@@ -4,12 +4,12 @@ use bracket_sim::load_teams_for_year;
 use clap::Parser;
 use std::io;
 use std::path::PathBuf;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use kalshi::orderbook;
 use kalshi::rest::{self, KalshiRestClient};
 use kalshi::team_names::{extract_team_name, load_team_name_map};
-use kalshi::types::{MARKETS, TeamOrderbook};
+use kalshi::types::{MARKETS, Orderbook, TeamOrderbook};
 
 fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
     let n: usize = s.parse().map_err(|e| format!("{e}"))?;
@@ -153,11 +153,38 @@ fn main() -> io::Result<()> {
             }
         };
 
-        // Try orderbook cache
+        // Filter to only tournament teams before fetching orderbooks
+        let total_markets = markets.len();
+        let markets: Vec<_> = markets
+            .into_iter()
+            .filter(|m| {
+                let raw_name = extract_team_name(m);
+                let canonical = name_map.get(&raw_name).cloned().unwrap_or(raw_name);
+                name_to_slot.contains_key(&canonical)
+            })
+            .collect();
+        info!(
+            round = market_def.label,
+            kept = markets.len(),
+            skipped = total_markets - markets.len(),
+            "filtered to tournament teams"
+        );
+
+        // Build ticker set for filtered markets
+        let market_tickers: std::collections::HashSet<String> =
+            markets.iter().map(|m| m.ticker.clone()).collect();
+
+        // Try orderbook cache, filtering to tournament teams
         let orderbooks = match rest::load_orderbook_cache(market_def, ttl) {
             Some(cached) => {
-                info!(round = market_def.label, "using cached orderbooks");
-                cached.orderbooks
+                // Cache may contain all teams — filter to only tournament tickers
+                let obs: Vec<_> = cached
+                    .orderbooks
+                    .into_iter()
+                    .filter(|ob| market_tickers.contains(&ob.ticker))
+                    .collect();
+                info!(round = market_def.label, count = obs.len(), "using cached orderbooks (filtered)");
+                obs
             }
             None => {
                 let c = client.get_or_insert_with(|| {
@@ -177,22 +204,24 @@ fn main() -> io::Result<()> {
             }
         };
 
+        // Build ticker → orderbook lookup for matching (handles both cached and fresh)
+        let ob_by_ticker: std::collections::HashMap<String, Orderbook> = orderbooks
+            .into_iter()
+            .map(|ob| (ob.ticker.clone(), ob))
+            .collect();
+
         // Resolve team names and build TeamOrderbook entries.
         // For First Four teams (e.g. "Texas"), resolve to the slot name ("Texas/NC State")
         // so calibration adjusts the correct bracket entry.
-        for (market, ob) in markets.iter().zip(orderbooks.into_iter()) {
+        for market in &markets {
             let raw_name = extract_team_name(market);
             let canonical = name_map.get(&raw_name).cloned().unwrap_or(raw_name.clone());
+            let slot_name = name_to_slot[&canonical].clone();
 
-            // Resolve to bracket slot name (handles both direct and FF team names).
-            let slot_name = match name_to_slot.get(&canonical) {
-                Some(slot) => slot.clone(),
+            let ob = match ob_by_ticker.get(&market.ticker) {
+                Some(ob) => ob.clone(),
                 None => {
-                    debug!(
-                        raw_name = %raw_name,
-                        canonical = %canonical,
-                        "skipping unknown team"
-                    );
+                    warn!(ticker = %market.ticker, "missing orderbook");
                     continue;
                 }
             };

--- a/data/mappings.toml
+++ b/data/mappings.toml
@@ -15,5 +15,11 @@
 "Queens" = "Queens (N.C.)"
 
 [kalshi]
-"Mississippi State" = "Mississippi St."
+"California Baptist" = "Cal Baptist"
 "Connecticut" = "UConn"
+"Hawai'i" = "Hawaii"
+"LIU" = "Long Island"
+"Miami (OH)" = "Miami (Ohio)"
+"Mississippi State" = "Mississippi St."
+"North Carolina St." = "NC State"
+"Queens University" = "Queens (N.C.)"

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Filter Kalshi calibration to tournament teams only
+- **Calibrate binary**: Markets are now filtered to only tournament teams (68) before fetching orderbooks, instead of fetching all ~150 markets per round. Cached orderbooks are also filtered by ticker on load.
+- **Mappings**: Added 6 missing Kalshi → NCAA name mappings to `data/mappings.toml` `[kalshi]` section: California Baptist, Hawai'i, LIU, Miami (OH), North Carolina St., Queens University.
 ### 2026-03-16 — Unsquish First Four teams in KenPom CSV
 - **Data**: `data/2026/men/kenpom.csv` now has one row per team (68 rows) instead of squishing First Four pairs into single rows with averaged metrics. Re-scraped from KenPom to get real individual ratings.
 - **Calibration**: New `save_kenpom_csv_with_goose()` in `bracket-sim/src/team.rs` preserves individual team metrics when writing calibrated goose values. For First Four teams, the slot's calibrated goose is applied to both individual team rows.

--- a/docs/prompts/cdai__kalshi-tournament-filter/1742148600-filter-kalshi-to-tournament.txt
+++ b/docs/prompts/cdai__kalshi-tournament-filter/1742148600-filter-kalshi-to-tournament.txt
@@ -1,0 +1,7 @@
+hey i see a big problem with our kalshi script...
+
+we try to scrape all the markets, not only the teams that are in the actual bracket. eventually we'll want to skip teams who are dead (eliminated) as well, or markets that have settled. but for now, stick with just: only scraping markets of teams in the tournament. currently that's 68 teams (normal 64 + first 4)
+
+it seems that kalshi market IDs are named differently than the team name we display in mappings. i think we'll need to add a section in mappings under the [kalshi] section that will go from ncaa name (in the tournament json) to kalshi market name. alternatiely we could do the inverse mapping to keep everythng consistently pointing to ncaa name (e.g. kalshi market ticker => ncaa name)
+
+you should look in the kalshi cache for these market ticker names to develop the mapping. pretty sure the cache is fully populated. only include names in the mapping that are in the actual tournament -- we have MORE  data than that in the cache


### PR DESCRIPTION
## Summary
- Filter markets to only the 68 tournament teams **before** fetching orderbooks (was fetching all ~150 per round)
- Added 6 missing Kalshi → NCAA name mappings in `data/mappings.toml`: California Baptist, Hawai'i, LIU, Miami (OH), North Carolina St., Queens University
- Cached orderbooks are filtered by ticker on load to handle old cache files that contain all teams

## Test plan
- [ ] `cargo build -p bracket-sim --bin calibrate` compiles clean
- [ ] `cargo clippy -p bracket-sim --bin calibrate -- -D warnings` passes
- [ ] Run calibrator and verify logs show `filtered to tournament teams` with ~68 kept per round
- [ ] Verify all 68 tournament teams resolve correctly (no "skipping unknown team" warnings)