### PR TITLE
Improve calibrator trade table alignment

### DIFF
--- a/crates/bracket-sim/src/bin/calibrate.rs
+++ b/crates/bracket-sim/src/bin/calibrate.rs
@@ -183,7 +183,11 @@ fn main() -> io::Result<()> {
                     .into_iter()
                     .filter(|ob| market_tickers.contains(&ob.ticker))
                     .collect();
-                info!(round = market_def.label, count = obs.len(), "using cached orderbooks (filtered)");
+                info!(
+                    round = market_def.label,
+                    count = obs.len(),
+                    "using cached orderbooks (filtered)"
+                );
                 obs
             }
             None => {

--- a/crates/kalshi/src/orderbook.rs
+++ b/crates/kalshi/src/orderbook.rs
@@ -217,16 +217,16 @@ pub fn print_trade_log(trades: &[Trade]) {
 
     println!();
     println!(
-        " {:<4} {:<max_team$}  {:>3}  {:>5}  {:>5}  {:>6}  {:>4}  {:>8}  URL",
-        "Side", "Team", "Rnd", "Price", "Model", "Edge", "Qty", "EV($)"
+        " {:<max_team$}   {:<4}   {:>3}   {:>5}   {:>5}   {:>6}   {:>4}   {:>8}   URL",
+        "Team", "Side", "Rnd", "Price", "Model", "Edge", "Qty", "EV($)"
     );
-    println!("{}", "-".repeat(max_team + 65));
+    println!("{}", "-".repeat(max_team + 74));
 
     for t in trades {
         println!(
-            " {:<4} {:<max_team$}  {:>3}  {:>4}\u{00a2}  {:>4.0}\u{00a2}  {:>5.1}\u{00a2}  {:>4}  ${:>7.2}  {}",
-            t.side,
+            " {:<max_team$}   {:<4}   {:>3}   {:>4}\u{00a2}   {:>4.0}\u{00a2}   {:>5.1}\u{00a2}   {:>4}   ${:>7.2}   {}",
             t.team,
+            t.side,
             round_label(t.round),
             t.price_cents,
             t.model_prob_cents,
@@ -238,10 +238,10 @@ pub fn print_trade_log(trades: &[Trade]) {
     }
 
     let total_ev: f64 = trades.iter().map(|t| t.ev_dollars).sum();
-    println!("{}", "-".repeat(max_team + 65));
+    println!("{}", "-".repeat(max_team + 74));
     println!(
-        " {:>max_team$}  {:>3}  {:>5}  {:>5}  {:>6}  {:>4}  ${:>7.2}",
-        "", "", "", "", "", "", total_ev
+        " {:<max_team$}   {:>4}   {:>3}   {:>5}   {:>5}   {:>6}   {:>4}   ${:>7.2}",
+        "", "", "", "", "", "", "", total_ev
     );
 }
 

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Improve calibrator trade table alignment
+- **Trade log table**: Moved "Team" to the first column and "Side" to the second column for better readability. Added extra spacing between all columns so the table is less cramped.
+- **Rust fmt**: Fixed a pre-existing `rustfmt` issue in `calibrate.rs`.
+
 ### 2026-03-16 — Filter Kalshi calibration to tournament teams only
 - **Calibrate binary**: Markets are now filtered to only tournament teams (68) before fetching orderbooks, instead of fetching all ~150 markets per round. Cached orderbooks are also filtered by ticker on load.
 - **Mappings**: Added 6 missing Kalshi → NCAA name mappings to `data/mappings.toml` `[kalshi]` section: California Baptist, Hawai'i, LIU, Miami (OH), North Carolina St., Queens University.

--- a/docs/prompts/cdai__improve-calibrator-table-alignment/1742134800-improve-table-alignment.txt
+++ b/docs/prompts/cdai__improve-calibrator-table-alignment/1742134800-improve-table-alignment.txt
@@ -1,0 +1,18 @@
+You're working on the march-madness project. The user wants to improve the table alignment of the kalshi calibrator's output at the bottom. Specifically:
+
+1. Move "team" to the very left column
+2. Move "side" to the 2nd column
+3. Give columns more space so the table looks nicer and more readable
+
+First, explore the codebase to find the kalshi calibrator output code. It's likely in `crates/bracket-sim/` or `crates/kalshi/`. Look for where the calibration results table is printed/formatted.
+
+Then fix the alignment to make it look much nicer. Make sure to run `./scripts/ci.sh` before finishing to verify nothing is broken.
+
+IMPORTANT project rules:
+- All git branches must be prefixed with `cdai__`
+- Update README.md and CLAUDE.md if behavior changes
+- Add entry to docs/changeset.md
+- Save this prompt to docs/prompts/<branch-name>/ as a .txt file
+- End with a PR
+
+Branch off main.


### PR DESCRIPTION
## Summary
- Move "Team" to the first column and "Side" to the second column in the calibrator's trade log table for better readability
- Add extra spacing between all columns so the table is less cramped
- Fix a pre-existing `rustfmt` issue in `calibrate.rs`

## Test plan
- [x] `crates build` passes
- [x] `crates test` passes
- [x] `crates fmt` passes
- [x] `crates clippy` passes
- [x] All other CI checks pass (contracts, packages, python)