### PR TITLE
Add hidden hex input easter egg for bracket filling

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Bracket hex input easter egg
+- **Frontend**: Added a hidden hex input next to the Reset Picks button. A faint `0x` hint is visible but not editable — double-click it to unlock the input field. Type or paste a valid bytes8 bracket hex string to auto-fill all 63 picks instantly. Input closes on blur (if empty) or on successful load. Only visible before the deadline.
+
 ### 2026-03-16 — Skip First Four teams in Kalshi calibration
 - **Calibrate binary**: First Four teams (e.g. Texas, NC State) are now excluded from Kalshi market-making calibration. Kalshi has separate individual markets for each FF team, not a joint market for the bracket slot. Including them produced nonsense combined-name URLs and incorrect calibration signals. FF teams conservatively keep goose=0.
 - **Filtering**: FF teams are filtered out at the market-selection step (before orderbook fetching), avoiding wasted API calls. A safety guard in the orderbook-to-TeamOrderbook loop catches any that slip through.

--- a/docs/prompts/cdai__paste-bracket-easter-egg/1742134800-paste-bracket-easter-egg.txt
+++ b/docs/prompts/cdai__paste-bracket-easter-egg/1742134800-paste-bracket-easter-egg.txt
@@ -1,0 +1,3 @@
+hey! so most users will manually fill out brackets. but i am a power user and i want to be able to PASTE in a bracket to the ui and have it auto-fill in the bracket for me. basically in that place where we show bracket, i want to be able to control that with input. it shouldn't be an advertised feature (almost a little bit like an easter egg) but it would save me a lot of time.
+
+when you're done, open a PR.

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -1,4 +1,7 @@
 import { usePrivy } from "@privy-io/react-auth";
+import { useRef, useState } from "react";
+
+import { validateBracket } from "@march-madness/client";
 
 import { BracketView } from "../components/BracketView";
 import { DeadlineCountdown } from "../components/DeadlineCountdown";
@@ -19,6 +22,21 @@ export function HomePage() {
   const { status: tournamentStatus } = useTournamentStatus();
 
   const isLocked = !contract.isBeforeDeadline;
+
+  // Easter egg: double-click to unlock hex input, type/paste a bracket to auto-fill
+  const [hexOpen, setHexOpen] = useState(false);
+  const [hexInput, setHexInput] = useState("");
+  const hexRef = useRef<HTMLInputElement>(null);
+  const handleHexInput = (value: string) => {
+    setHexInput(value);
+    const trimmed = value.trim();
+    if (validateBracket(trimmed)) {
+      bracket.loadFromHex(trimmed as `0x${string}`);
+      setHexInput("");
+      setHexOpen(false);
+    }
+  };
+
   const showFaucetBanner =
     authenticated &&
     contract.walletAddress &&
@@ -39,12 +57,34 @@ export function HomePage() {
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
         <DeadlineCountdown />
         {!isLocked && (
-          <button
-            onClick={bracket.resetPicks}
-            className="px-3 py-2 text-xs rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
-          >
-            Reset Picks
-          </button>
+          <>
+            <button
+              onClick={bracket.resetPicks}
+              className="px-3 py-2 text-xs rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+            >
+              Reset Picks
+            </button>
+            {hexOpen ? (
+              <input
+                ref={hexRef}
+                type="text"
+                value={hexInput}
+                onChange={(e) => handleHexInput(e.target.value)}
+                onBlur={() => { if (!hexInput) setHexOpen(false); }}
+                placeholder="0x..."
+                spellCheck={false}
+                autoFocus
+                className="w-40 px-2 py-1.5 text-xs font-mono rounded-lg bg-bg-tertiary border border-accent/50 text-text-primary placeholder-text-muted/50 focus:outline-none transition-colors"
+              />
+            ) : (
+              <span
+                onDoubleClick={() => setHexOpen(true)}
+                className="px-2 py-1.5 text-xs font-mono text-text-muted/30 select-none cursor-default"
+              >
+                0x
+              </span>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Adds a subtle `0x` hint next to the "Reset Picks" button on the bracket picker page
- Double-click the `0x` to unlock a text input field — type or paste a valid bytes8 bracket hex string to auto-fill all 63 picks instantly
- Input auto-closes on blur (if empty) or after a successful bracket load
- Only visible before the submission deadline — power-user easter egg, not advertised

## Test plan
- [ ] Verify `0x` text is barely visible next to Reset Picks (very muted styling)
- [ ] Verify single-clicking `0x` does nothing
- [ ] Verify double-clicking `0x` opens the text input with autofocus
- [ ] Paste a valid bracket hex (e.g. `0xbf3af97f5dbafc01`) — all 63 picks should fill in
- [ ] Type a valid hex character by character — fills on completion
- [ ] Invalid hex stays in the input (doesn't clear or close)
- [ ] Click away from empty input — it closes back to `0x` hint
- [ ] After deadline, neither `0x` hint nor input is visible