### PR TITLE
Fix blank team names in bracket UI

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Fix blank team names in bracket UI
+- **Bug**: Team names were blank because `BracketGame` rendered `team.abbrev` but `tournament.json` has no `abbrev` field — only `name`, `seed`, `region`. The value was `undefined`, rendering as empty text with no console error.
+- **Fix**: Made `abbrev` optional in the `Team` interface and added `team.abbrev ?? team.name` fallback in `BracketGame` so team names always display.
+
 ### 2026-03-16 — Bracket hex input easter egg
 - **Frontend**: Added a hidden hex input next to the Reset Picks button. A faint `0x` hint is visible but not editable — double-click it to unlock the input field. Type or paste a valid bytes8 bracket hex string to auto-fill all 63 picks instantly. Input closes on blur (if empty) or on successful load. Only visible before the deadline.
 

--- a/docs/prompts/cdai__fix-bracket-hex-input/1742137400-fix-blank-teams-hex-input.txt
+++ b/docs/prompts/cdai__fix-bracket-hex-input/1742137400-fix-blank-teams-hex-input.txt
@@ -1,0 +1,7 @@
+make a new branch off main, bc i merged this pr.
+
+i just pasted in my hex string, and nothing happens!
+
+i dont see consol errors either... please fix
+
+OH. a bigger bug is... i dont see the teams loading at ALL!

--- a/packages/web/src/components/BracketGame.tsx
+++ b/packages/web/src/components/BracketGame.tsx
@@ -182,7 +182,7 @@ function TeamSlot({
         <span className={`text-text-muted ${mobile ? "mr-0.5" : "mr-1.5"} font-normal`}>
           {team.seed}
         </span>
-        <span>{team.abbrev}</span>
+        <span>{team.abbrev ?? team.name}</span>
         {pickCorrect && (
           <span className="ml-1 text-green-400 text-[10px]">&#10003;</span>
         )}

--- a/packages/web/src/lib/tournament.ts
+++ b/packages/web/src/lib/tournament.ts
@@ -5,7 +5,7 @@ export interface Team {
   name: string;
   seed: number;
   region: string;
-  abbrev: string;
+  abbrev?: string;
 }
 
 export interface TournamentData {


### PR DESCRIPTION
## Summary
- Team names were blank because `BracketGame` rendered `team.abbrev` but `tournament.json` only has `name`, `seed`, `region` — no `abbrev` field
- `undefined` rendered as empty text with no console error, making it look like teams didn't load
- Made `abbrev` optional in `Team` interface, added `team.abbrev ?? team.name` fallback
- This also fixes the hex input easter egg appearing to do nothing — picks were being set correctly but team names were invisible

## Test plan
- [ ] Verify team names (e.g. "Duke", "Florida") display in all bracket game slots
- [ ] Verify hex input easter egg works: double-click `0x`, paste a bracket hex, picks fill in with visible team names
- [ ] Verify bracket picking still works normally (click team to advance)