### PR TITLE
Fix hex input paste + sentinel bit warning

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,13 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Fix hex input paste not working
+- **Bug**: Pasting a bracket hex into the easter egg input did nothing — three root causes:
+  1. Used `validateBracket()` which requires the sentinel bit (first nibble >= 8), but bracket hex from simulations/tools often omits it. The sentinel is only needed for on-chain submission, not for loading picks.
+  2. `onBlur` handler captured stale `hexInput` state (always `""` from initial render), so any blur event immediately closed the input
+  3. Only relied on `onChange` for paste detection, which can be unreliable
+- **Fix**: Replaced `validateBracket` with a simple `0x` + 16 hex char regex (no sentinel requirement). Added dedicated `onPaste` handler that reads directly from `clipboardData`. Fixed `onBlur` to check `hexRef.current.value` (DOM truth) instead of stale React state. Strips non-hex characters from pasted text.
+
 ### 2026-03-16 — Fix blank team names in bracket UI
 - **Bug**: Team names were blank because `BracketGame` rendered `team.abbrev` but `tournament.json` has no `abbrev` field — only `name`, `seed`, `region`. The value was `undefined`, rendering as empty text with no console error.
 - **Fix**: Made `abbrev` optional in the `Team` interface and added `team.abbrev ?? team.name` fallback in `BracketGame` so team names always display.

--- a/docs/prompts/cdai__fix-hex-input-paste/1742138400-fix-paste-not-working.txt
+++ b/docs/prompts/cdai__fix-hex-input-paste/1742138400-fix-paste-not-working.txt
@@ -1,0 +1,5 @@
+ok... so now the teams all load... but i still can't submit brackets with hex. i paste in the hex, and no dice
+
+also in a background agent: make an issue to make the group joining + "Your name" input way nicer... it is way too long on desktop mode
+
+work off a fresh branch from main, bc i merged the last PR.

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
 import { usePrivy } from "@privy-io/react-auth";
 import { useRef, useState } from "react";
 
-import { validateBracket } from "@march-madness/client";
 
 import { BracketView } from "../components/BracketView";
 import { DeadlineCountdown } from "../components/DeadlineCountdown";
@@ -26,14 +25,36 @@ export function HomePage() {
   // Easter egg: double-click to unlock hex input, type/paste a bracket to auto-fill
   const [hexOpen, setHexOpen] = useState(false);
   const [hexInput, setHexInput] = useState("");
+  const [hexError, setHexError] = useState<string | null>(null);
   const hexRef = useRef<HTMLInputElement>(null);
-  const handleHexInput = (value: string) => {
+  const tryLoadHex = (raw: string) => {
+    // Strip whitespace and any non-hex garbage that might come from copy-paste
+    const cleaned = raw.replace(/[^0-9a-fA-Fx]/g, "");
+    // Need 0x + exactly 16 hex chars
+    if (!/^0x[0-9a-fA-F]{16}$/.test(cleaned)) {
+      setHexError(null); // Not a complete hex yet, no error
+      return false;
+    }
+    // Check sentinel bit — warn but still load
+    const firstNibble = parseInt(cleaned[2], 16);
+    if (firstNibble < 8) {
+      setHexError("Missing sentinel bit — picks loaded but bracket is invalid for on-chain submission");
+    } else {
+      setHexError(null);
+    }
+    bracket.loadFromHex(cleaned as `0x${string}`);
+    setHexInput("");
+    setHexOpen(false);
+    return true;
+  };
+  const handleHexChange = (value: string) => {
     setHexInput(value);
-    const trimmed = value.trim();
-    if (validateBracket(trimmed)) {
-      bracket.loadFromHex(trimmed as `0x${string}`);
-      setHexInput("");
-      setHexOpen(false);
+    tryLoadHex(value);
+  };
+  const handleHexPaste = (e: React.ClipboardEvent) => {
+    const pasted = e.clipboardData.getData("text");
+    if (tryLoadHex(pasted)) {
+      e.preventDefault();
     }
   };
 
@@ -69,8 +90,12 @@ export function HomePage() {
                 ref={hexRef}
                 type="text"
                 value={hexInput}
-                onChange={(e) => handleHexInput(e.target.value)}
-                onBlur={() => { if (!hexInput) setHexOpen(false); }}
+                onChange={(e) => handleHexChange(e.target.value)}
+                onPaste={handleHexPaste}
+                onBlur={() => {
+                  // Check the DOM value directly to avoid stale closure
+                  if (!hexRef.current?.value) setHexOpen(false);
+                }}
                 placeholder="0x..."
                 spellCheck={false}
                 autoFocus
@@ -87,6 +112,12 @@ export function HomePage() {
           </>
         )}
       </div>
+
+      {hexError && (
+        <div className="mb-2 px-3 py-1.5 text-xs text-yellow-400 bg-yellow-400/10 border border-yellow-400/30 rounded-lg">
+          {hexError}
+        </div>
+      )}
 
       <div className="mb-6 sm:mb-8">
         <SubmitPanel


### PR DESCRIPTION
## Summary
- **Root cause**: `validateBracket()` requires the sentinel bit (first nibble >= 8), but bracket hex from simulations/tools often omits it. `0x2d551133fffdfdff` starts with `2` → rejected silently.
- Now accepts any `0x` + 16 hex chars. Picks load regardless of sentinel bit.
- If sentinel bit is missing, shows a yellow warning: "Missing sentinel bit — picks loaded but bracket is invalid for on-chain submission"
- Also fixed: `onBlur` stale closure (checked React state instead of DOM ref), added dedicated `onPaste` handler, strips non-hex characters from pasted text

## Test plan
- [ ] Paste `0x2d551133fffdfdff` (no sentinel) → picks fill in + yellow warning appears
- [ ] Paste `0xad551133fffdfdff` (has sentinel) → picks fill in, no warning
- [ ] Type hex character by character → fills on 18th char
- [ ] Click away from empty input → closes back to `0x` hint
- [ ] Warning dismisses when bracket is reset or new valid hex is loaded