### PR TITLE
Show encoded bracket hex when picks are complete

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Show encoded bracket hex when picks are complete
+- **Frontend**: The faint `0x` easter egg placeholder now shows the full encoded bracket hex (e.g. `0xad551133fffdfdff`) once all 63 picks are made. Slightly more visible than the empty `0x` hint. Still double-clickable to open the hex input for loading a different bracket.
+
 ### 2026-03-16 — Fix hex input paste not working
 - **Bug**: Pasting a bracket hex into the easter egg input did nothing — three root causes:
   1. Used `validateBracket()` which requires the sentinel bit (first nibble >= 8), but bracket hex from simulations/tools often omits it. The sentinel is only needed for on-chain submission, not for loading picks.

--- a/docs/prompts/cdai__show-encoded-bracket/1742140200-show-encoded-bracket.txt
+++ b/docs/prompts/cdai__show-encoded-bracket/1742140200-show-encoded-bracket.txt
@@ -1,0 +1,1 @@
+alright new branch... i noticed that AFTER i submitted a bracket, it zeroes out that "0x" hidden input location... i would like it to remain there -- we used to display it before and i like it

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -104,9 +104,9 @@ export function HomePage() {
             ) : (
               <span
                 onDoubleClick={() => setHexOpen(true)}
-                className="px-2 py-1.5 text-xs font-mono text-text-muted/30 select-none cursor-default"
+                className={`px-2 py-1.5 text-xs font-mono select-none cursor-default ${bracket.encodedBracket ? "text-text-muted" : "text-text-muted/30"}`}
               >
-                0x
+                {bracket.encodedBracket ?? "0x"}
               </span>
             )}
           </>


### PR DESCRIPTION
## Summary
- The faint `0x` easter egg placeholder now shows the full encoded bracket hex (e.g. `0xad551133fffdfdff`) once all 63 picks are made
- Slightly more visible styling (`text-text-muted` vs `text-text-muted/30`) so you can read it
- Still double-clickable to open the hex input for loading a different bracket

## Test plan
- [ ] With 0 picks: faint `0x` shows (barely visible)
- [ ] With partial picks: still faint `0x`
- [ ] With all 63 picks: full hex string displays (e.g. `0xad551133fffdfdff`)
- [ ] Double-click the hex string → input opens, can paste a new bracket
- [ ] After loading new bracket via paste, hex updates to reflect new picks