### PR TITLE
Add copy/edit fan-out icons on bracket hex double-click

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Add copy/edit fan-out icons on hex display double-click
+- **Frontend**: Double-clicking the bracket hex value now fans out a copy icon and an edit (pencil) icon instead of immediately opening the hex input. Copy writes `bracket.encodedBracket` to clipboard with "Copied!" feedback; edit opens the existing hex input easter egg. Icons auto-collapse after 3 seconds or on click outside. Smooth `max-w` + opacity transition for the fan-out animation.
+
 ### 2026-03-16 — Fix bracket-sim ByteBracket encoding to match contract (MSB-first)
 - **Bug**: `bracket-sim` encoded game outcomes LSB-first (game 0 → bit 0) while `ByteBracket.sol` and the TS client use MSB-first (game 0 → bit 62, sentinel at bit 63). Hex strings from the sim decoded as "mostly 16 seeds win" in the UI because all bit positions were reversed.
 - **Root cause**: bracket-sim was self-consistent (LSB encoding + LSB scoring) so its internal roundtrip tests passed. The golden test vectors from issue #63 were never added to bracket-sim, so the cross-language mismatch went undetected.

--- a/docs/prompts/cdai__hex-copy/1773637514-hex-copy.txt
+++ b/docs/prompts/cdai__hex-copy/1773637514-hex-copy.txt
@@ -1,0 +1,1 @@
+in my bracket hex display, there's no way for me to copy the value. i think the nicest thing would be: if i double click it, it should fan out a copy icon, to copy the current value (even if that isn't displayed)

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { usePrivy } from "@privy-io/react-auth";
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 
 import { BracketView } from "../components/BracketView";
@@ -22,11 +22,48 @@ export function HomePage() {
 
   const isLocked = !contract.isBeforeDeadline;
 
-  // Easter egg: double-click to unlock hex input, type/paste a bracket to auto-fill
+  // Easter egg: double-click to fan out copy/edit icons, edit opens hex input
   const [hexOpen, setHexOpen] = useState(false);
+  const [hexExpanded, setHexExpanded] = useState(false);
+  const [hexCopied, setHexCopied] = useState(false);
   const [hexInput, setHexInput] = useState("");
   const [hexError, setHexError] = useState<string | null>(null);
   const hexRef = useRef<HTMLInputElement>(null);
+  const expandRef = useRef<HTMLDivElement>(null);
+  const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Auto-collapse after 3s of no interaction
+  const scheduleCollapse = useCallback(() => {
+    if (collapseTimer.current) clearTimeout(collapseTimer.current);
+    collapseTimer.current = setTimeout(() => {
+      setHexExpanded(false);
+      setHexCopied(false);
+    }, 3000);
+  }, []);
+
+  // Click-outside to collapse
+  useEffect(() => {
+    if (!hexExpanded) return;
+    const handler = (e: MouseEvent) => {
+      if (expandRef.current && !expandRef.current.contains(e.target as Node)) {
+        setHexExpanded(false);
+        setHexCopied(false);
+        if (collapseTimer.current) clearTimeout(collapseTimer.current);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [hexExpanded]);
+
+  const handleCopy = async () => {
+    if (!bracket.encodedBracket) return;
+    await navigator.clipboard.writeText(bracket.encodedBracket);
+    setHexCopied(true);
+    setTimeout(() => {
+      setHexCopied(false);
+      setHexExpanded(false);
+    }, 1200);
+  };
   const tryLoadHex = (raw: string) => {
     // Strip whitespace and any non-hex garbage that might come from copy-paste
     const cleaned = raw.replace(/[^0-9a-fA-Fx]/g, "");
@@ -102,12 +139,52 @@ export function HomePage() {
                 className="w-40 px-2 py-1.5 text-xs font-mono rounded-lg bg-bg-tertiary border border-accent/50 text-text-primary placeholder-text-muted/50 focus:outline-none transition-colors"
               />
             ) : (
-              <span
-                onDoubleClick={() => setHexOpen(true)}
-                className={`px-2 py-1.5 text-xs font-mono select-none cursor-default ${bracket.encodedBracket ? "text-text-muted" : "text-text-muted/30"}`}
-              >
-                {bracket.encodedBracket ?? "0x"}
-              </span>
+              <div ref={expandRef} className="relative flex items-center">
+                <span
+                  onDoubleClick={() => {
+                    setHexExpanded((prev) => !prev);
+                    scheduleCollapse();
+                  }}
+                  className={`px-2 py-1.5 text-xs font-mono select-none cursor-default ${bracket.encodedBracket ? "text-text-muted" : "text-text-muted/30"}`}
+                >
+                  {bracket.encodedBracket ?? "0x"}
+                </span>
+                {/* Fan-out action icons */}
+                <div
+                  className={`flex items-center gap-1 overflow-hidden transition-all duration-200 ease-out ${hexExpanded ? "max-w-[120px] opacity-100" : "max-w-0 opacity-0"}`}
+                >
+                  {hexCopied ? (
+                    <span className="px-1.5 py-1 text-[10px] text-green-400 whitespace-nowrap">
+                      Copied!
+                    </span>
+                  ) : (
+                    <button
+                      onClick={handleCopy}
+                      title="Copy hex"
+                      className="p-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                        <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z" />
+                        <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.439A1.5 1.5 0 0 0 8.378 6H4.5Z" />
+                      </svg>
+                    </button>
+                  )}
+                  <button
+                    onClick={() => {
+                      setHexExpanded(false);
+                      setHexOpen(true);
+                      if (collapseTimer.current) clearTimeout(collapseTimer.current);
+                    }}
+                    title="Edit hex"
+                    className="p-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                      <path d="m5.433 13.917 1.262-3.155A4 4 0 0 1 7.58 9.42l6.92-6.918a2.121 2.121 0 0 1 3 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 0 1-.65-.65Z" />
+                      <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0 0 10 3H4.75A2.75 2.75 0 0 0 2 5.75v9.5A2.75 2.75 0 0 0 4.75 18h9.5A2.75 2.75 0 0 0 17 15.25V10a.75.75 0 0 0-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5Z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- Double-clicking the bracket hex display now fans out a **copy icon** (clipboard) and **edit icon** (pencil) instead of immediately opening the hex input
- Copy icon writes `bracket.encodedBracket` to clipboard with brief green "Copied!" feedback, then auto-collapses
- Edit icon opens the existing hex input easter egg for pasting a new bracket
- Icons auto-collapse after 3 seconds of inactivity or on click outside
- Smooth `max-w` + opacity CSS transition for the fan-out animation

## Test plan
- [ ] Make some picks (or all 63) so the hex value is non-empty
- [ ] Double-click the hex text — verify copy and edit icons fan out smoothly
- [ ] Click copy icon — verify clipboard contains the hex value and "Copied!" shows briefly
- [ ] Click edit icon — verify hex input opens for entering/pasting a bracket
- [ ] Wait 3s without clicking — verify icons auto-collapse
- [ ] Click outside the hex area — verify icons collapse
- [ ] Double-click again to toggle open/closed