### PR TITLE
Auto-fix sentinel bit on pasted hex brackets

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Auto-fix sentinel bit on pasted hex brackets
+- **Behavior change**: When a user pastes a bracket hex with a missing sentinel bit (bit 63), the UI now automatically flips the bit to make it valid instead of loading the invalid hex as-is.
+- **UX**: Warning message now shows both the original pasted hex and the corrected hex so the user knows exactly what changed.
+
 ### 2026-03-16 — Make MirrorsSection discoverable with track/untrack UI
 - **Problem**: MirrorsSection was completely invisible — it only rendered when `mirrorIds.length > 0`, and the only way to add mirror IDs was programmatically via localStorage. No input, no form, no way for users to discover or use mirrors.
 - **Fix**: Always show MirrorsSection when a mirror contract is deployed. Added a "Track Mirror" form (accepts mirror ID or slug, validated on-chain) that saves to localStorage. Added "Untrack" button on each tracked mirror. Made `mirrorIds` state reactive so tracking/untracking updates the UI immediately.

--- a/docs/prompts/cdai__fix-sentinel-hex/1773638400-fix-sentinel-hex.txt
+++ b/docs/prompts/cdai__fix-sentinel-hex/1773638400-fix-sentinel-hex.txt
@@ -1,0 +1,3 @@
+you know how we give a warning if they paste in hex with invalid sentinel byte, and say it's invalid on chain but we filled in their picks? why don't we change the behaviour to:
+1) if they paste an invalid hex string, edit it to be valid (flip sentinel bit to 1)
+2) in the warning message say "you pasted in invalid hex {X}, we updated it to {Y} which is the same bracket with sentinel bit on" <- something like that, that's a little verbose, we should definitely print out X and Y though

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -73,14 +73,17 @@ export function HomePage() {
       setHexError(null); // Not a complete hex yet, no error
       return false;
     }
-    // Check sentinel bit — warn but still load
+    // Check sentinel bit — if missing, fix it by setting bit 63 (MSB)
     const firstNibble = parseInt(cleaned[2], 16);
     if (firstNibble < 8) {
-      setHexError("Missing sentinel bit — picks loaded but bracket is invalid for on-chain submission");
+      const fixedNibble = (firstNibble | 0x8).toString(16);
+      const fixed = `0x${fixedNibble}${cleaned.slice(3)}` as `0x${string}`;
+      setHexError(`Pasted ${cleaned} — missing sentinel bit. Loaded ${fixed} (same picks, valid for submission).`);
+      bracket.loadFromHex(fixed);
     } else {
       setHexError(null);
+      bracket.loadFromHex(cleaned as `0x${string}`);
     }
-    bracket.loadFromHex(cleaned as `0x${string}`);
     setHexInput("");
     setHexOpen(false);
     return true;


### PR DESCRIPTION
## Summary
- When pasting a bracket hex with missing sentinel bit (bit 63 not set), instead of loading it as-is with a vague warning, we now **auto-fix** it by setting the bit
- Warning message shows both values: `Pasted 0x1234... — missing sentinel bit. Loaded 0x9234... (same picks, valid for submission).`

## Test plan
- [ ] Paste a valid hex (sentinel bit set) — loads normally, no warning
- [ ] Paste an invalid hex (e.g. `0x1234567890abcdef`) — auto-corrects to `0x9234567890abcdef`, shows warning with both values
- [ ] Verify the corrected bracket has identical picks to the original