### PR TITLE
Add passphrase field and invite links for private group joining

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,11 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Add passphrase field and invite links for private group joining
+- **Fix**: Private groups were impossible to join from the UI — no passphrase input existed. Added a passphrase field to the "Join a Group" form.
+- **UX**: When a slug resolves to a password-protected group, the passphrase field highlights and an error message prompts the user to enter the passphrase.
+- **Feature**: Shareable invite links for private groups (e.g., `/groups?slug=seismic-team&password=Quake100`). URL query params auto-populate the slug and passphrase fields. Invite link shown with copy button in the joined groups list for private groups.
+
 ### 2026-03-16 — Auto-fix sentinel bit on pasted hex brackets
 - **Behavior change**: When a user pastes a bracket hex with a missing sentinel bit (bit 63), the UI now automatically flips the bit to make it valid instead of loading the invalid hex as-is.
 - **UX**: Warning message now shows both the original pasted hex and the corrected hex so the user knows exactly what changed.

--- a/docs/prompts/cdai__private-group-join-ui/1742137200-private-group-join.txt
+++ b/docs/prompts/cdai__private-group-join-ui/1742137200-private-group-join.txt
@@ -1,0 +1,6 @@
+two things...
+
+1) when i create a private group, i'm not automaticaly added as a member... maaaybe that's fine but
+2) i can't join a private group at all -- you need to give us an option on the "Join a group" UI to type in a password if it's a private group
+
+Also: i think it would be nice if i could paste someone a URL and it would automatically populate all of the fields to join the private group -- meaning password and slug. for example, seismic-team as slug, and pssword = Quake100.

--- a/packages/web/src/components/GroupsSection.tsx
+++ b/packages/web/src/components/GroupsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { JoinedGroup } from "../hooks/useGroups";
+import type { GroupData } from "@march-madness/client";
 
 interface GroupsSectionProps {
   joinedGroups: JoinedGroup[];
@@ -8,10 +9,13 @@ interface GroupsSectionProps {
   isBeforeDeadline: boolean;
   walletConnected: boolean;
   onJoinGroup: (groupId: number, name: string, entryFee: bigint) => Promise<unknown>;
+  onJoinGroupWithPassword: (groupId: number, passphrase: string, name: string, entryFee: bigint) => Promise<unknown>;
   onLeaveGroup: (groupId: number) => Promise<unknown>;
   onEditEntryName: (groupId: number, name: string) => Promise<unknown>;
-  onLookupBySlug: (slug: string) => Promise<[number, unknown] | null>;
+  onLookupBySlug: (slug: string) => Promise<[number, GroupData] | null>;
   onTrackGroup: (groupId: number) => void;
+  initialSlug?: string;
+  initialPassphrase?: string;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -39,16 +43,24 @@ export function GroupsSection({
   isBeforeDeadline,
   walletConnected,
   onJoinGroup,
+  onJoinGroupWithPassword,
   onLeaveGroup,
   onEditEntryName,
   onLookupBySlug,
   onTrackGroup,
+  initialSlug = "",
+  initialPassphrase = "",
 }: GroupsSectionProps) {
-  const [joinInput, setJoinInput] = useState("");
+  const [joinInput, setJoinInput] = useState(initialSlug);
   const [nameInput, setNameInput] = useState("");
+  const [passphraseInput, setPassphraseInput] = useState(initialPassphrase);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [editingGroup, setEditingGroup] = useState<number | null>(null);
   const [editName, setEditName] = useState("");
+  // Track whether the resolved group needs a password
+  const [resolvedGroupNeedsPassword, setResolvedGroupNeedsPassword] = useState<boolean | null>(
+    initialPassphrase ? true : null,
+  );
 
   const handleJoin = async () => {
     if (!joinInput.trim() || !nameInput.trim()) return;
@@ -58,6 +70,7 @@ export function GroupsSection({
       // Try parsing as group ID first
       const asNumber = parseInt(joinInput, 10);
       let groupId: number;
+      let groupData: GroupData | null = null;
 
       if (!isNaN(asNumber) && String(asNumber) === joinInput.trim()) {
         groupId = asNumber;
@@ -69,11 +82,28 @@ export function GroupsSection({
           return;
         }
         groupId = result[0];
+        groupData = result[1];
       }
 
-      await onJoinGroup(groupId, nameInput.trim(), 0n);
+      // If we have group data, check if password is needed
+      if (groupData?.hasPassword) {
+        if (!passphraseInput.trim()) {
+          setResolvedGroupNeedsPassword(true);
+          setJoinError("This is a private group — enter the passphrase to join");
+          return;
+        }
+        await onJoinGroupWithPassword(groupId, passphraseInput.trim(), nameInput.trim(), 0n);
+      } else if (passphraseInput.trim()) {
+        // User provided a passphrase — try with password in case it's needed
+        await onJoinGroupWithPassword(groupId, passphraseInput.trim(), nameInput.trim(), 0n);
+      } else {
+        await onJoinGroup(groupId, nameInput.trim(), 0n);
+      }
+
       setJoinInput("");
       setNameInput("");
+      setPassphraseInput("");
+      setResolvedGroupNeedsPassword(null);
     } catch (err) {
       setJoinError(err instanceof Error ? err.message : "Failed to join");
     }
@@ -133,12 +163,23 @@ export function GroupsSection({
                 </span>
               </div>
 
-              {/* Passphrase display for private groups */}
+              {/* Passphrase + invite link for private groups */}
               {storedInfo.passphrase && (
-                <div className="flex items-center text-xs text-text-secondary mb-2 bg-bg-primary rounded px-2 py-1">
-                  <span className="text-text-tertiary mr-1">Passphrase:</span>
-                  <span className="text-text-primary">{storedInfo.passphrase}</span>
-                  <CopyButton text={storedInfo.passphrase} />
+                <div className="space-y-1 mb-2">
+                  <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
+                    <span className="text-text-tertiary mr-1">Passphrase:</span>
+                    <span className="text-text-primary">{storedInfo.passphrase}</span>
+                    <CopyButton text={storedInfo.passphrase} />
+                  </div>
+                  <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
+                    <span className="text-text-tertiary mr-1">Invite link:</span>
+                    <span className="text-text-primary truncate">
+                      {`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
+                    </span>
+                    <CopyButton
+                      text={`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
+                    />
+                  </div>
                 </div>
               )}
 
@@ -223,21 +264,32 @@ export function GroupsSection({
       {walletConnected && isBeforeDeadline && (
         <div className="max-w-lg space-y-2">
           <h3 className="text-sm font-medium text-text-secondary">Join a Group</h3>
-          <div className="flex flex-col sm:flex-row gap-2">
-            <input
-              type="text"
-              value={joinInput}
-              onChange={(e) => setJoinInput(e.target.value)}
-              placeholder="Group ID or slug"
-              className="sm:w-40 px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
-            />
-            <input
-              type="text"
-              value={nameInput}
-              onChange={(e) => setNameInput(e.target.value)}
-              placeholder="Your name"
-              className="sm:w-36 px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
-            />
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input
+                type="text"
+                value={joinInput}
+                onChange={(e) => setJoinInput(e.target.value)}
+                placeholder="Group ID or slug"
+                className="sm:w-40 px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+              />
+              <input
+                type="text"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                placeholder="Your name"
+                className="sm:w-36 px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+              />
+              <input
+                type="text"
+                value={passphraseInput}
+                onChange={(e) => setPassphraseInput(e.target.value)}
+                placeholder={resolvedGroupNeedsPassword ? "Passphrase (required)" : "Passphrase (if private)"}
+                className={`sm:w-40 px-3 py-1.5 text-sm rounded-lg bg-bg-primary border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors ${
+                  resolvedGroupNeedsPassword ? "border-amber-500/50" : "border-border"
+                }`}
+              />
+            </div>
             <div className="flex gap-2">
               <button
                 onClick={handleJoin}

--- a/packages/web/src/pages/GroupsPage.tsx
+++ b/packages/web/src/pages/GroupsPage.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
+import { useSearchParams } from "react-router-dom";
 
 import { GroupsSection } from "../components/GroupsSection";
 import { useContract } from "../hooks/useContract";
@@ -17,6 +18,11 @@ export function GroupsPage() {
   const { authenticated } = usePrivy();
   const contract = useContract();
   const groups = useGroups();
+  const [searchParams] = useSearchParams();
+
+  // Read invite link params (e.g., /groups?slug=seismic-team&password=Quake100)
+  const initialSlug = useMemo(() => searchParams.get("slug") ?? "", [searchParams]);
+  const initialPassphrase = useMemo(() => searchParams.get("password") ?? "", [searchParams]);
 
   // Create group form state
   const [displayName, setDisplayName] = useState("");
@@ -174,10 +180,13 @@ export function GroupsPage() {
           isBeforeDeadline={contract.isBeforeDeadline}
           walletConnected={authenticated}
           onJoinGroup={groups.joinGroup}
+          onJoinGroupWithPassword={groups.joinGroupWithPassword}
           onLeaveGroup={groups.leaveGroup}
           onEditEntryName={groups.editEntryName}
           onLookupBySlug={groups.lookupGroupBySlug}
           onTrackGroup={groups.trackGroup}
+          initialSlug={initialSlug}
+          initialPassphrase={initialPassphrase}
         />
       )}
 

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -238,6 +238,7 @@ export function HomePage() {
             isBeforeDeadline={contract.isBeforeDeadline}
             walletConnected={authenticated}
             onJoinGroup={groups.joinGroup}
+            onJoinGroupWithPassword={groups.joinGroupWithPassword}
             onLeaveGroup={groups.leaveGroup}
             onEditEntryName={groups.editEntryName}
             onLookupBySlug={groups.lookupGroupBySlug}


### PR DESCRIPTION
## Summary
- **Fix**: Private groups were impossible to join from the UI — no passphrase input existed. Added a passphrase field to the "Join a Group" form on both the Groups page and the Home page.
- **UX**: When a slug resolves to a password-protected group and no passphrase is provided, the field highlights amber and an error prompts the user. If a passphrase is provided (even for groups looked up by ID), it's sent as a password join.
- **Feature**: Shareable invite links like `/groups?slug=seismic-team&password=Quake100`. URL query params auto-populate the slug and passphrase fields. Private groups in the joined list show a copyable invite link.

## Test plan
- [ ] Create a private group with a passphrase
- [ ] Try joining it without a passphrase — should see error + highlighted field
- [ ] Enter passphrase and join — should succeed
- [ ] Copy the invite link from joined groups list
- [ ] Open the invite link in a new tab — slug and passphrase should be pre-filled
- [ ] Join via the pre-filled invite link