### PR TITLE
Remove Groups and Mirrors sections from homepage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "rayon",
+ "seismic-march-madness",
  "serde",
  "serde_json",
  "statrs",

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Remove Groups and Mirrors sections from homepage
+- **Cleanup**: Removed GroupsSection and MirrorsSection from the homepage. Groups already have a dedicated `/groups` page. Mirrors will get a dedicated `/mirrors` page later (see issue).
+- **No functional change**: MirrorsSection component is kept in the codebase for future use.
+
 ### 2026-03-16 — Add passphrase field and invite links for private group joining
 - **Fix**: Private groups were impossible to join from the UI — no passphrase input existed. Added a passphrase field to the "Join a Group" form.
 - **UX**: When a slug resolves to a password-protected group, the passphrase field highlights and an error message prompts the user to enter the passphrase.

--- a/docs/prompts/cdai__remove-mirrors-homepage/1742137800-remove-mirrors-homepage.txt
+++ b/docs/prompts/cdai__remove-mirrors-homepage/1742137800-remove-mirrors-homepage.txt
@@ -1,0 +1,6 @@
+on a sepaate branch: i also have no way to create a mirror in the UI. not to mention, the UI for Groups and Mirrors is still on the home page. I think you should ONLY have it on the /groups and /mirrors page. there's no mirrors page currently, but there should be a UI for it. i guess it's less important now (maybe don't display mirrors at all on the frontend for now -- just get rid of that initial section. we'll add the feature later).. so make a pr that removes "mirrors" from the homepage, and then put up an issue saying we should create a UI for mirrors:
+
+in the mirrors UI, we should be able to:
+1) create a mirror
+2) include a link so people can include the mirror in their frontend (much like you're building for groups with ?slug=seismic-team&password=Quake100
+3) allow the admin to easily punch in mirrors. they can either: (1) paste in hex codes (2) manually fill in brackets for each mirror entry they are adding. UI should look the same as it does for users submitting brackets

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -5,19 +5,15 @@ import { BracketView } from "../components/BracketView";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { DeadlineCountdown } from "../components/DeadlineCountdown";
 import { FaucetBanner } from "../components/FaucetBanner";
-import { GroupsSection } from "../components/GroupsSection";
-import { MirrorsSection } from "../components/MirrorsSection";
 import { SubmitPanel } from "../components/SubmitPanel";
 import { useBracket } from "../hooks/useBracket";
 import { useContract } from "../hooks/useContract";
-import { useGroups } from "../hooks/useGroups";
 import { useTournamentStatus } from "../hooks/useTournamentStatus";
 
 export function HomePage() {
   const { authenticated } = usePrivy();
   const contract = useContract();
   const bracket = useBracket(contract.walletAddress);
-  const groups = useGroups();
   const { status: tournamentStatus } = useTournamentStatus();
 
   const isLocked = !contract.isBeforeDeadline;
@@ -226,30 +222,6 @@ export function HomePage() {
           onLoadBracket={handleLoadBracket}
           walletConnected={authenticated}
         />
-      </div>
-
-      {/* Groups section — prominent for both pre- and post-lock */}
-      {groups.hasContract && (
-        <div className="mb-6 sm:mb-8">
-          <GroupsSection
-            joinedGroups={groups.joinedGroups}
-            isLoading={groups.isLoading}
-            error={groups.error}
-            isBeforeDeadline={contract.isBeforeDeadline}
-            walletConnected={authenticated}
-            onJoinGroup={groups.joinGroup}
-            onJoinGroupWithPassword={groups.joinGroupWithPassword}
-            onLeaveGroup={groups.leaveGroup}
-            onEditEntryName={groups.editEntryName}
-            onLookupBySlug={groups.lookupGroupBySlug}
-            onTrackGroup={groups.trackGroup}
-          />
-        </div>
-      )}
-
-      {/* Mirrors — tucked away, only shows if user has tracked mirrors */}
-      <div className="mb-6 sm:mb-8">
-        <MirrorsSection />
       </div>
 
       <BracketView


### PR DESCRIPTION
## Summary
- Removed GroupsSection and MirrorsSection from the homepage — both belong on their dedicated pages
- Groups already has `/groups`; Mirrors will get `/mirrors` (tracked in a separate issue)
- Homepage now focuses purely on bracket picking and submission

## Test plan
- [ ] Verify homepage no longer shows Groups or Mirrors sections
- [ ] Verify `/groups` page still works as expected