### PR TITLE
Move Groups before Leaderboard in nav, track by slug

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Move Groups before Leaderboard in nav, track by slug
+- **UX**: Reordered nav bar so Groups appears before Leaderboard (both desktop and mobile).
+- **UX**: Replaced "Track by group ID" with "Track by slug" — looks up groups on-chain by slug instead of numeric ID, with error feedback.
+
 ### 2026-03-16 — Fix group join flow: entry fees, slug-first lookup, layout
 - **Bug fix**: Joining a group with a non-zero entry fee now correctly populates the transaction value. Previously always sent 0.
 - **UX**: Join flow now fetches group metadata before submitting the tx — validates group exists, checks wallet balance vs entry fee, and surfaces clear error messages.

--- a/docs/prompts/cdai__nav-groups-first/1742137200-nav-reorder-and-track-by-slug.txt
+++ b/docs/prompts/cdai__nav-groups-first/1742137200-nav-reorder-and-track-by-slug.txt
@@ -1,0 +1,7 @@
+in the top bar of the UI, let's move "Groups" to the left of "Leaderboard". leaderboard isn't useful right now; groups is
+
+ok also... "Already a member? Track by group Id section"....
+
+i thinkw e should nix this, and also require them to enter a slug here.
+
+can you create pr

--- a/packages/web/src/components/GroupsSection.tsx
+++ b/packages/web/src/components/GroupsSection.tsx
@@ -47,7 +47,8 @@ export function GroupsSection({
     initialPassphrase ? true : null,
   );
   // Track by ID form
-  const [trackIdInput, setTrackIdInput] = useState("");
+  const [trackSlugInput, setTrackSlugInput] = useState("");
+  const [trackError, setTrackError] = useState("");
 
   /** Resolve a slug to [groupId, GroupData]. Returns null if not found. */
   const resolveGroup = async (input: string) => {
@@ -108,11 +109,17 @@ export function GroupsSection({
     }
   };
 
-  const handleTrackById = () => {
-    const id = parseInt(trackIdInput, 10);
-    if (!isNaN(id)) {
-      groups.trackGroup(id);
-      setTrackIdInput("");
+  const handleTrackBySlug = async () => {
+    const slug = trackSlugInput.trim();
+    if (!slug) return;
+    setTrackError("");
+    const result = await groups.lookupGroupBySlug(slug);
+    if (result) {
+      const [groupId] = result;
+      groups.trackGroup(groupId);
+      setTrackSlugInput("");
+    } else {
+      setTrackError(`No group found with slug "${slug}"`);
     }
   };
 
@@ -306,25 +313,26 @@ export function GroupsSection({
             <p className="text-xs text-red-400">{joinError}</p>
           )}
 
-          {/* Track by ID (separate, small) */}
+          {/* Track by slug (separate, small) */}
           <div className="pt-2 border-t border-border">
-            <h4 className="text-xs text-text-tertiary mb-1">Already a member? Track by group ID</h4>
+            <h4 className="text-xs text-text-tertiary mb-1">Already a member? Track by slug</h4>
             <div className="flex gap-2">
               <input
                 type="text"
-                value={trackIdInput}
-                onChange={(e) => setTrackIdInput(e.target.value)}
-                placeholder="Group ID"
-                className="w-28 px-3 py-1 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+                value={trackSlugInput}
+                onChange={(e) => { setTrackSlugInput(e.target.value); setTrackError(""); }}
+                placeholder="group-slug"
+                className="flex-1 px-3 py-1 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
               />
               <button
-                onClick={handleTrackById}
-                disabled={!trackIdInput.trim()}
+                onClick={handleTrackBySlug}
+                disabled={!trackSlugInput.trim()}
                 className="px-3 py-1 text-sm rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary transition-colors"
               >
                 Track
               </button>
             </div>
+            {trackError && <p className="text-xs text-red-400 mt-1">{trackError}</p>}
           </div>
         </div>
       )}

--- a/packages/web/src/components/Header.tsx
+++ b/packages/web/src/components/Header.tsx
@@ -61,11 +61,11 @@ export function Header() {
               <Link to="/" className={navLinkClass("/")}>
                 Bracket
               </Link>
-              <Link to="/leaderboard" className={navLinkClass("/leaderboard")}>
-                Leaderboard
-              </Link>
               <Link to="/groups" className={navLinkClass("/groups")}>
                 Groups
+              </Link>
+              <Link to="/leaderboard" className={navLinkClass("/leaderboard")}>
+                Leaderboard
               </Link>
             </nav>
           )}
@@ -152,18 +152,18 @@ export function Header() {
                   Bracket
                 </Link>
                 <Link
-                  to="/leaderboard"
-                  onClick={() => setMenuOpen(false)}
-                  className="block px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover transition-colors"
-                >
-                  Leaderboard
-                </Link>
-                <Link
                   to="/groups"
                   onClick={() => setMenuOpen(false)}
                   className="block px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover transition-colors"
                 >
                   Groups
+                </Link>
+                <Link
+                  to="/leaderboard"
+                  onClick={() => setMenuOpen(false)}
+                  className="block px-4 py-2.5 text-sm text-text-secondary hover:bg-bg-hover transition-colors"
+                >
+                  Leaderboard
                 </Link>
                 {authenticated && address && (
                   <button


### PR DESCRIPTION
## Summary
- Reorders nav bar so **Groups** appears before **Leaderboard** (desktop + mobile menu) — groups are more useful right now.
- Replaces "Track by group ID" with "Track by slug" — looks up groups on-chain via `getGroupBySlug`, shows error if not found.

## Test plan
- [ ] Verify Groups link appears before Leaderboard in desktop nav
- [ ] Verify same ordering in mobile hamburger menu
- [ ] Enter a valid group slug in "Track by slug" → group is tracked
- [ ] Enter an invalid slug → error message shown