### PR TITLE
Show Load bracket hint in reset picks dialog

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Reset picks dialog hints about reloading on-chain bracket
+- **UX**: When user has an on-chain submission, the reset picks confirmation tells them they can reload it via "Load bracket" instead of "can't be undone".
+
 ### 2026-03-16 — Move Groups before Leaderboard in nav, track by slug
 - **UX**: Reordered nav bar so Groups appears before Leaderboard (both desktop and mobile).
 - **UX**: Replaced "Track by group ID" with "Track by slug" — looks up groups on-chain by slug instead of numeric ID, with error feedback.

--- a/docs/prompts/cdai__reset-picks-hint/1742137500-reset-picks-load-hint.txt
+++ b/docs/prompts/cdai__reset-picks-hint/1742137500-reset-picks-load-hint.txt
@@ -1,0 +1,4 @@
+in the "are you sure you want to reset picks?" question
+
+ONLY if they had submitted a value on chain, we should alter that confirm prompt to say:
+"You can re-load your on-chain submission by clicking "Load bracket""

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -127,7 +127,11 @@ export function HomePage() {
               onClose={() => setResetOpen(false)}
               onConfirm={bracket.resetPicks}
               title="Reset Picks?"
-              description="This will clear all 63 picks. This can't be undone."
+              description={
+                contract.hasSubmitted
+                  ? "This will clear all 63 picks. You can re-load your on-chain submission by clicking \"Load bracket\"."
+                  : "This will clear all 63 picks. This can't be undone."
+              }
               confirmLabel="Reset"
               cancelLabel="Cancel"
               danger


### PR DESCRIPTION
## Summary
- When user has an on-chain submission, the reset picks confirmation now says: "You can re-load your on-chain submission by clicking 'Load bracket'." instead of "This can't be undone."
- No-op for users who haven't submitted yet — they still see the original warning.

## Test plan
- [ ] Without on-chain submission: reset dialog says "This can't be undone."
- [ ] With on-chain submission: reset dialog mentions "Load bracket" recovery option