### PR TITLE
Extract shared SlugInput, fix track-by-slug width

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Shared SlugInput component, fix track-by-slug width
+- **Refactor**: Extract shared `SlugInput` component used by both join form and track-by-slug inputs — consistent sizing (`max-w-md`, `text-sm`, `py-1.5`).
+- **UX**: Track-by-slug input now matches join form width instead of stretching full-width.
+
 ### 2026-03-16 — Reset picks dialog hints about reloading on-chain bracket
 - **UX**: When user has an on-chain submission, the reset picks confirmation tells them they can reload it via "Load bracket" instead of "can't be undone".
 

--- a/docs/prompts/cdai__slug-input-component/1742138000-shared-slug-input.txt
+++ b/docs/prompts/cdai__slug-input-component/1742138000-shared-slug-input.txt
@@ -1,0 +1,5 @@
+the "Already a member? Track by slug" is too wide. make it narrower. should be the same font size and width as "Group slug" section of join-a group
+
+but i do like the placeholder is "group-slug" and not "Group slug"
+
+those two should use a common component targeting different state variables...

--- a/packages/web/src/components/GroupsSection.tsx
+++ b/packages/web/src/components/GroupsSection.tsx
@@ -29,6 +29,26 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
+function SlugInput({
+  value,
+  onChange,
+  placeholder = "group-slug",
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className="w-full max-w-md px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+    />
+  );
+}
+
 export function GroupsSection({
   groups,
   isBeforeDeadline,
@@ -276,13 +296,7 @@ export function GroupsSection({
         <div className="space-y-3">
           <h3 className="text-sm font-medium text-text-secondary">Join a Group</h3>
           <div className="space-y-2">
-            <input
-              type="text"
-              value={slugInput}
-              onChange={(e) => setSlugInput(e.target.value)}
-              placeholder="Group slug"
-              className="w-full max-w-md px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
-            />
+            <SlugInput value={slugInput} onChange={setSlugInput} placeholder="Group slug" />
             <input
               type="text"
               value={nameInput}
@@ -316,18 +330,15 @@ export function GroupsSection({
           {/* Track by slug (separate, small) */}
           <div className="pt-2 border-t border-border">
             <h4 className="text-xs text-text-tertiary mb-1">Already a member? Track by slug</h4>
-            <div className="flex gap-2">
-              <input
-                type="text"
+            <div className="flex gap-2 max-w-md">
+              <SlugInput
                 value={trackSlugInput}
-                onChange={(e) => { setTrackSlugInput(e.target.value); setTrackError(""); }}
-                placeholder="group-slug"
-                className="flex-1 px-3 py-1 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+                onChange={(v) => { setTrackSlugInput(v); setTrackError(""); }}
               />
               <button
                 onClick={handleTrackBySlug}
                 disabled={!trackSlugInput.trim()}
-                className="px-3 py-1 text-sm rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary transition-colors"
+                className="px-3 py-1.5 text-sm rounded-lg bg-bg-tertiary border border-border text-text-secondary hover:text-text-primary transition-colors whitespace-nowrap"
               >
                 Track
               </button>


### PR DESCRIPTION
## Summary
- Extracts a shared `SlugInput` component used by both the "Join a Group" slug field and the "Track by slug" field — same sizing, font, and `max-w-md` constraint.
- Track-by-slug input no longer stretches full width (`flex-1`); it now matches the join form's dimensions.
- Join form keeps `placeholder="Group slug"`, track form keeps `placeholder="group-slug"`.

## Test plan
- [ ] Join form slug input looks the same as before
- [ ] Track-by-slug input is now the same width as the join slug input
- [ ] Both inputs have consistent font size and padding