### PR TITLE
Remove dead Ethereum March Madness link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A private, on-chain NCAA March Madness bracket contest built on the [Seismic Net
 
 Built on [jimpo's march-madness-dapp](https://github.com/jimpo/march-madness-dapp). The bracket encoding and scoring use his ByteBracket library directly, which implements the compact scoring algorithm by [pursuingpareto](https://gist.github.com/pursuingpareto/b15f1197d96b1a2bbc48). jimpo's original project ran on Ethereum with Truffle; we've ported it to Seismic with modern tooling.
 
-The bracket pool smart contract was also inspired by the work of the [Ethereum March Madness](https://github.com/EthereumMarchMadness) team.
-
 ## How It Works
 
 1. **Connect** — Sign in with your Twitter, Discord, or other social account via Privy

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Remove dead Ethereum March Madness link from README
+- **Docs**: Remove dead link to `github.com/EthereumMarchMadness` from Credits section.
+
 ### 2026-03-16 — Shared SlugInput component, fix track-by-slug width
 - **Refactor**: Extract shared `SlugInput` component used by both join form and track-by-slug inputs — consistent sizing (`max-w-md`, `text-sm`, `py-1.5`).
 - **UX**: Track-by-slug input now matches join form width instead of stretching full-width.

--- a/docs/prompts/cdai__remove-dead-link/1742107200-remove-dead-link.txt
+++ b/docs/prompts/cdai__remove-dead-link/1742107200-remove-dead-link.txt
@@ -1,0 +1,5 @@
+ok great. finally, theres a section in here:
+
+"The bracket pool smart contract was also inspired by the work of the Ethereum March Madness team."
+
+this is a dead link. you can remove it.


### PR DESCRIPTION
## Summary
- Remove dead link to `github.com/EthereumMarchMadness` from the Credits section of README.md — the GitHub org no longer exists.
- Cleanup before open-sourcing the repo.

## Test plan
- [ ] Verify the remaining jimpo and pursuingpareto links in Credits still work