### PR TITLE
Auto-join creator when creating a BracketGroups group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,8 @@ Standalone admin-managed off-chain bracket pool mirror. No money, no scoring, no
 
 Linked sub-groups composing with MarchMadness. Optional password + entry fee.
 
-- `createGroup(slug, displayName, entryFee)` → groupId (public)
-- `createGroupWithPassword(slug, displayName, entryFee, sbytes12 password)` → groupId (private)
+- `createGroup(slug, displayName, entryFee)` → groupId (public, payable — creator auto-joined with name "CREATOR")
+- `createGroupWithPassword(slug, displayName, entryFee, sbytes12 password)` → groupId (private, payable — creator auto-joined with name "CREATOR")
 - `joinGroup(groupId, name)` / `joinGroupWithPassword(groupId, sbytes12 password, name)` — payable, always requires name
 - `leaveGroup(groupId)` — refund before submission deadline
 - `editEntryName(groupId, name)` — update display name

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A later-round pick only scores if the feeder games were also picked correctly.
 Two separate contracts for side pools alongside the main contest:
 
 - **Mirrors** (`BracketMirror`): Admin enters external brackets (bracket + slug) from off-chain pools (e.g. Yahoo Fantasy). No money, no scoring on-chain — purely for display. Admin sets a prize description for bookkeeping.
-- **Groups** (`BracketGroups`): Users self-join with their main-contract bracket. Optional password protection (`sbytes12(keccak256("your-password"))`). Optional entry fee creates a side-bet prize pool. Winners split the pool after scoring.
+- **Groups** (`BracketGroups`): Creating a group auto-joins the creator (default name "CREATOR", editable). Other users self-join with their main-contract bracket. Optional password protection (`sbytes12(keccak256("your-password"))`). Optional entry fee creates a side-bet prize pool. Winners split the pool after scoring.
 
 ## Tech Stack
 

--- a/contracts/src/BracketGroups.sol
+++ b/contracts/src/BracketGroups.sol
@@ -106,22 +106,26 @@ contract BracketGroups {
     //  GROUP LIFECYCLE
     // ════════════════════════════════════════════════════════════════════
 
-    /// @notice Create a public group (no password).
+    /// @notice Create a public group (no password). Creator is auto-joined with name "CREATOR".
+    ///         Send entry fee as msg.value (0 for free groups).
     function createGroup(string calldata slug, string calldata displayName, uint256 entryFee)
         external
+        payable
         returns (uint32 groupId)
     {
         groupId = _createGroup(slug, displayName, entryFee, false);
     }
 
-    /// @notice Create a password-protected group. Password is stored shielded (sbytes12).
+    /// @notice Create a password-protected group. Creator is auto-joined with name "CREATOR".
+    ///         Password is stored shielded (sbytes12).
     ///         Frontend converts user's string password to bytes12 (e.g. keccak256 truncated) before sending.
+    ///         Send entry fee as msg.value (0 for free groups).
     function createGroupWithPassword(
         string calldata slug,
         string calldata displayName,
         uint256 entryFee,
         sbytes12 password
-    ) external returns (uint32 groupId) {
+    ) external payable returns (uint32 groupId) {
         groupId = _createGroup(slug, displayName, entryFee, true);
         _passwords[groupId] = password;
     }
@@ -151,6 +155,9 @@ contract BracketGroups {
         slugToGroupId[slugHash] = groupId;
 
         emit GroupCreated(groupId, slug, displayName, msg.sender, hasPassword);
+
+        // Auto-join the creator with default name "CREATOR" (editable via editEntryName)
+        _joinGroup(groupId, "CREATOR");
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/contracts/test/BracketGroups.t.sol
+++ b/contracts/test/BracketGroups.t.sol
@@ -35,15 +35,20 @@ contract BracketGroupsTest is Test {
         vm.deal(alice, 100 ether);
         vm.deal(bob, 100 ether);
         vm.deal(charlie, 100 ether);
+
+        // Creator needs a bracket in the main contract to create groups (auto-join requires it).
+        // Uses BAD bracket so creator doesn't interfere with scoring/payout test expectations.
+        vm.prank(creator);
+        mm.submitBracket{value: ENTRY_FEE}(sbytes8(BAD));
     }
 
     // ════════════════════════════════════════════════════════════════════
-    //  GROUP CREATION
+    //  GROUP CREATION (with auto-join)
     // ════════════════════════════════════════════════════════════════════
 
     function test_createGroup() public {
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("side-bet", "Side Bet", 0.1 ether);
+        uint32 groupId = bg.createGroup{value: 0.1 ether}("side-bet", "Side Bet", 0.1 ether);
 
         assertEq(groupId, 1);
         (uint32 slugId, BracketGroups.Group memory g) = bg.getGroupBySlug("side-bet");
@@ -51,9 +56,16 @@ contract BracketGroupsTest is Test {
         assertEq(g.slug, "side-bet");
         assertEq(g.displayName, "Side Bet");
         assertEq(g.creator, creator);
-        assertEq(g.entryCount, 0);
+        assertEq(g.entryCount, 1); // creator auto-joined
         assertEq(g.entryFee, 0.1 ether);
         assertFalse(g.hasPassword);
+
+        // Creator is auto-joined with default name
+        assertTrue(bg.isMemberOf(groupId, creator));
+        BracketGroups.Member[] memory members = bg.getMembers(groupId);
+        assertEq(members.length, 1);
+        assertEq(members[0].addr, creator);
+        assertEq(members[0].name, "CREATOR");
     }
 
     function test_createGroupWithPassword() public {
@@ -63,6 +75,21 @@ contract BracketGroupsTest is Test {
         BracketGroups.Group memory g = bg.getGroup(groupId);
         assertTrue(g.hasPassword);
         assertEq(g.slug, "private");
+        assertEq(g.entryCount, 1); // creator auto-joined
+        assertTrue(bg.isMemberOf(groupId, creator));
+    }
+
+    function test_creatorCanEditName() public {
+        vm.prank(creator);
+        uint32 groupId = bg.createGroup("bet", "Bet", 0);
+
+        // Creator auto-joined with "CREATOR" name
+        assertEq(bg.getMembers(groupId)[0].name, "CREATOR");
+
+        // Creator edits their name
+        vm.prank(creator);
+        bg.editEntryName(groupId, "The Boss");
+        assertEq(bg.getMembers(groupId)[0].name, "The Boss");
     }
 
     function test_duplicateSlugReverts() public {
@@ -75,11 +102,13 @@ contract BracketGroupsTest is Test {
     }
 
     function test_emptySlugReverts() public {
+        vm.prank(creator);
         vm.expectRevert(BracketGroups.SlugCannotBeEmpty.selector);
         bg.createGroup("", "Bet", 0);
     }
 
     function test_longSlugReverts() public {
+        vm.prank(creator);
         vm.expectRevert(BracketGroups.SlugTooLong.selector);
         bg.createGroup("this-slug-is-way-too-long-and-exceeds-the-32-byte-limit", "Bet", 0);
     }
@@ -97,12 +126,37 @@ contract BracketGroupsTest is Test {
     function test_multipleGroups() public {
         vm.prank(creator);
         uint32 g1 = bg.createGroup("g1", "G1", 0);
+
         vm.prank(alice);
-        uint32 g2 = bg.createGroup("g2", "G2", 0.5 ether);
+        mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
+        vm.prank(alice);
+        uint32 g2 = bg.createGroup{value: 0.5 ether}("g2", "G2", 0.5 ether);
 
         assertEq(g1, 1);
         assertEq(g2, 2);
         assertEq(bg.getGroup(g2).creator, alice);
+        assertTrue(bg.isMemberOf(g2, alice));
+    }
+
+    function test_createGroup_rejectWithoutMainBracket() public {
+        // charlie has no bracket in main contract
+        vm.prank(charlie);
+        vm.expectRevert(BracketGroups.NoBracketInMainContract.selector);
+        bg.createGroup("bet", "Bet", 0);
+    }
+
+    function test_createGroup_rejectWrongFee() public {
+        vm.prank(creator);
+        vm.expectRevert(abi.encodeWithSelector(BracketGroups.IncorrectEntryFee.selector, 0.1 ether, 0.05 ether));
+        bg.createGroup{value: 0.05 ether}("bet", "Bet", 0.1 ether);
+    }
+
+    function test_createGroup_rejectAfterDeadline() public {
+        vm.warp(DEADLINE);
+
+        vm.prank(creator);
+        vm.expectRevert(BracketGroups.CannotJoinAfterDeadline.selector);
+        bg.createGroup("bet", "Bet", 0);
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -111,7 +165,7 @@ contract BracketGroupsTest is Test {
 
     function test_joinGroup() public {
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", 0.1 ether);
+        uint32 groupId = bg.createGroup{value: 0.1 ether}("bet", "Bet", 0.1 ether);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -121,12 +175,14 @@ contract BracketGroupsTest is Test {
 
         assertTrue(bg.isMemberOf(groupId, alice));
         assertTrue(bg.getIsMember(groupId, alice));
-        assertEq(bg.getGroup(groupId).entryCount, 1);
+        assertEq(bg.getGroup(groupId).entryCount, 2); // creator + alice
 
         BracketGroups.Member[] memory members = bg.getMembers(groupId);
-        assertEq(members.length, 1);
-        assertEq(members[0].name, "Alice");
-        assertEq(members[0].addr, alice);
+        assertEq(members.length, 2);
+        assertEq(members[0].name, "CREATOR"); // creator auto-joined
+        assertEq(members[0].addr, creator);
+        assertEq(members[1].name, "Alice");
+        assertEq(members[1].addr, alice);
     }
 
     function test_joinGroup_rejectDuplicate() public {
@@ -154,7 +210,7 @@ contract BracketGroupsTest is Test {
 
     function test_joinGroup_rejectWrongFee() public {
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", 0.1 ether);
+        uint32 groupId = bg.createGroup{value: 0.1 ether}("bet", "Bet", 0.1 ether);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -180,7 +236,7 @@ contract BracketGroupsTest is Test {
 
     function test_leaveGroup_refund() public {
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", 0.5 ether);
+        uint32 groupId = bg.createGroup{value: 0.5 ether}("bet", "Bet", 0.5 ether);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -193,7 +249,7 @@ contract BracketGroupsTest is Test {
 
         assertEq(alice.balance - balBefore, 0.5 ether);
         assertFalse(bg.isMemberOf(groupId, alice));
-        assertEq(bg.getGroup(groupId).entryCount, 0);
+        assertEq(bg.getGroup(groupId).entryCount, 1); // only creator remains
     }
 
     function test_leaveGroup_swapAndPop() public {
@@ -214,14 +270,16 @@ contract BracketGroupsTest is Test {
         vm.prank(charlie);
         bg.joinGroup(groupId, "Charlie");
 
-        // Alice leaves (index 0) — charlie swaps in
+        // creator=0, alice=1, bob=2, charlie=3
+        // Alice leaves (index 1) — charlie swaps in
         vm.prank(alice);
         bg.leaveGroup(groupId);
 
-        assertEq(bg.getGroup(groupId).entryCount, 2);
+        assertEq(bg.getGroup(groupId).entryCount, 3);
         BracketGroups.Member[] memory members = bg.getMembers(groupId);
-        assertEq(members[0].addr, charlie);
-        assertEq(members[1].addr, bob);
+        assertEq(members[0].addr, creator);
+        assertEq(members[1].addr, charlie);
+        assertEq(members[2].addr, bob);
     }
 
     function test_leaveGroup_blockedAfterDeadline() public {
@@ -252,7 +310,7 @@ contract BracketGroupsTest is Test {
         vm.prank(alice);
         bg.editEntryName(groupId, "Alice the Great");
 
-        assertEq(bg.getMembers(groupId)[0].name, "Alice the Great");
+        assertEq(bg.getMembers(groupId)[1].name, "Alice the Great");
     }
 
     // ════════════════════════════════════════════════════════════════════
@@ -270,7 +328,7 @@ contract BracketGroupsTest is Test {
         bg.joinGroupWithPassword(groupId, sbytes12(PASSWORD), "Alice");
 
         assertTrue(bg.isMemberOf(groupId, alice));
-        assertEq(bg.getMembers(groupId)[0].name, "Alice");
+        assertEq(bg.getMembers(groupId)[1].name, "Alice");
     }
 
     function test_joinPasswordGroup_wrongPassword() public {
@@ -301,7 +359,8 @@ contract BracketGroupsTest is Test {
 
     function test_joinPasswordGroup_withFee() public {
         vm.prank(creator);
-        uint32 groupId = bg.createGroupWithPassword("private", "Private", 0.5 ether, sbytes12(PASSWORD));
+        uint32 groupId =
+            bg.createGroupWithPassword{value: 0.5 ether}("private", "Private", 0.5 ether, sbytes12(PASSWORD));
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -310,7 +369,7 @@ contract BracketGroupsTest is Test {
         bg.joinGroupWithPassword{value: 0.5 ether}(groupId, sbytes12(PASSWORD), "Alice");
 
         assertTrue(bg.isMemberOf(groupId, alice));
-        assertEq(address(bg).balance, 0.5 ether);
+        assertEq(address(bg).balance, 1.0 ether); // creator + alice fee
     }
 
     function test_publicJoinOnPasswordlessGroup() public {
@@ -342,9 +401,9 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
 
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1); // alice is index 1
 
-        assertEq(bg.getMemberScore(groupId, 0), 192);
+        assertEq(bg.getMemberScore(groupId, 1), 192);
         // Also scored on main contract
         assertTrue(mm.isScored(alice));
         assertEq(mm.scores(alice), 192);
@@ -367,8 +426,8 @@ contract BracketGroupsTest is Test {
         assertTrue(mm.isScored(alice));
 
         // Group scoring should still work (reads existing score)
-        bg.scoreEntry(groupId, 0);
-        assertEq(bg.getMemberScore(groupId, 0), 192);
+        bg.scoreEntry(groupId, 1);
+        assertEq(bg.getMemberScore(groupId, 1), 192);
     }
 
     function test_scoreEntry_afterWindowIfAlreadyScoredOnMain() public {
@@ -390,7 +449,7 @@ contract BracketGroupsTest is Test {
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
 
         vm.expectRevert(BracketGroups.ScoringWindowClosed.selector);
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
     }
 
     function test_scoreEntry_revertsBeforeResults() public {
@@ -403,7 +462,7 @@ contract BracketGroupsTest is Test {
         bg.joinGroup(groupId, "Alice");
 
         vm.expectRevert(IMarchMadness.ResultsNotPosted.selector);
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
     }
 
     function test_scoreEntry_revertsAlreadyScored() public {
@@ -418,9 +477,9 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
 
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
         vm.expectRevert(BracketGroups.AlreadyScored.selector);
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
     }
 
     function test_scoreEntry_revertsAfterScoringWindow() public {
@@ -438,13 +497,13 @@ contract BracketGroupsTest is Test {
 
         // Not scored on main, so scoreBracket will revert with ScoringWindowClosed
         vm.expectRevert(BracketGroups.ScoringWindowClosed.selector);
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
     }
 
     function test_collectWinnings_singleWinner() public {
         uint256 groupFee = 0.5 ether;
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", groupFee);
+        uint32 groupId = bg.createGroup{value: groupFee}("bet", "Bet", groupFee);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -459,21 +518,23 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
 
+        // Score all 3: creator(BAD,idx=0), alice(PERFECT,idx=1), bob(BAD,idx=2)
         bg.scoreEntry(groupId, 0);
         bg.scoreEntry(groupId, 1);
+        bg.scoreEntry(groupId, 2);
 
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
 
         uint256 aliceBefore = alice.balance;
         vm.prank(alice);
         bg.collectWinnings(groupId);
-        assertEq(alice.balance - aliceBefore, 2 * groupFee);
+        assertEq(alice.balance - aliceBefore, 3 * groupFee); // sole winner gets entire pool
     }
 
     function test_collectWinnings_twoWinnersSplit() public {
         uint256 groupFee = 0.5 ether;
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", groupFee);
+        uint32 groupId = bg.createGroup{value: groupFee}("bet", "Bet", groupFee);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -492,13 +553,16 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
 
+        // Score all 4: creator(BAD,0), alice(PERFECT,1), bob(PERFECT,2), charlie(BAD,3)
         bg.scoreEntry(groupId, 0);
         bg.scoreEntry(groupId, 1);
         bg.scoreEntry(groupId, 2);
+        bg.scoreEntry(groupId, 3);
 
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
 
-        uint256 expectedPayout = (3 * groupFee) / 2;
+        // 4 members * 0.5 ether = 2.0 pool, split between 2 winners = 1.0 each
+        uint256 expectedPayout = (4 * groupFee) / 2;
 
         uint256 aliceBefore = alice.balance;
         vm.prank(alice);
@@ -514,7 +578,7 @@ contract BracketGroupsTest is Test {
     function test_collectWinnings_nonWinnerReverts() public {
         uint256 groupFee = 0.5 ether;
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", groupFee);
+        uint32 groupId = bg.createGroup{value: groupFee}("bet", "Bet", groupFee);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -530,6 +594,7 @@ contract BracketGroupsTest is Test {
         mm.submitResults(RESULTS);
         bg.scoreEntry(groupId, 0);
         bg.scoreEntry(groupId, 1);
+        bg.scoreEntry(groupId, 2);
 
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
 
@@ -541,7 +606,7 @@ contract BracketGroupsTest is Test {
     function test_collectWinnings_cannotCollectTwice() public {
         uint256 groupFee = 0.5 ether;
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", groupFee);
+        uint32 groupId = bg.createGroup{value: groupFee}("bet", "Bet", groupFee);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -551,6 +616,7 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
         bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
 
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
 
@@ -564,7 +630,7 @@ contract BracketGroupsTest is Test {
     function test_collectWinnings_revertsBeforeScoringWindow() public {
         uint256 groupFee = 0.5 ether;
         vm.prank(creator);
-        uint32 groupId = bg.createGroup("bet", "Bet", groupFee);
+        uint32 groupId = bg.createGroup{value: groupFee}("bet", "Bet", groupFee);
 
         vm.prank(alice);
         mm.submitBracket{value: ENTRY_FEE}(sbytes8(PERFECT));
@@ -574,6 +640,7 @@ contract BracketGroupsTest is Test {
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
         bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
 
         vm.prank(alice);
         vm.expectRevert(BracketGroups.ScoringWindowStillOpen.selector);
@@ -591,8 +658,8 @@ contract BracketGroupsTest is Test {
 
         vm.warp(DEADLINE + 1);
         mm.submitResults(RESULTS);
-        bg.scoreEntry(groupId, 0);
-        assertEq(bg.getMemberScore(groupId, 0), 192);
+        bg.scoreEntry(groupId, 1);
+        assertEq(bg.getMemberScore(groupId, 1), 192);
 
         vm.warp(mm.resultsPostedAt() + bg.SCORING_DURATION());
         vm.prank(alice);
@@ -604,10 +671,11 @@ contract BracketGroupsTest is Test {
         vm.prank(creator);
         uint32 groupId = bg.createGroup("bet", "Bet", 0);
 
+        // Group has 1 member (creator at index 0), so index 1 is out of bounds
         vm.expectRevert(BracketGroups.IndexOutOfBounds.selector);
-        bg.scoreEntry(groupId, 0);
+        bg.scoreEntry(groupId, 1);
 
         vm.expectRevert(BracketGroups.IndexOutOfBounds.selector);
-        bg.getMember(groupId, 0);
+        bg.getMember(groupId, 1);
     }
 }

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,12 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Auto-join creator when creating a BracketGroups group
+- **Contract**: `createGroup` and `createGroupWithPassword` now auto-join the creator as the first member with default name "CREATOR". Both functions are now `payable` — creator sends the group entry fee (if any) with the transaction. Creator can update their name via `editEntryName`.
+- **Client**: `createGroup` / `createGroupWithPassword` in `BracketGroupsUserClient` now automatically send `value: entryFee`.
+- **Frontend**: `useGroups` hook now tracks the newly created group in localStorage immediately after creation (looks up group ID by slug).
+- **Tests**: Updated all BracketGroups tests for auto-join behavior. Added tests for creator auto-join, name editing, and creation validation (no bracket, wrong fee, after deadline).
+
 ### 2026-03-16 — Prevent post-window BracketGroups scoring and add groups-only redeploy script
 - **Bug fix**: `BracketGroups.scoreEntry()` now reverts once the main scoring window has closed, even if the member was already scored on `MarchMadness`. This prevents group winner state from changing after claims are live.
 - **Tests**: Updated `BracketGroups.t.sol` to expect the closed-window revert for post-window group scoring.

--- a/docs/prompts/cdai__auto-join-on-create/1742140800-auto-join-creator.txt
+++ b/docs/prompts/cdai__auto-join-on-create/1742140800-auto-join-creator.txt
@@ -1,0 +1,5 @@
+hey really annoying thing about the groups contract...
+
+when you create a group, it doesn't automatically join for you. we should make edits to the groups contract so that we automatically join (including sending the appropriate value in the tx, per what they specify as the feel)
+
+i think this means we have to make creator ALSO pass in a name. if we can make them NOT put in a name, and default it to "CREATOR", that's cool with me, SO LONG AS people can edit their names. it's critical they can edit the name field if they wish. implement this feature and when you're done, open a pr

--- a/packages/client/src/abi-groups.ts
+++ b/packages/client/src/abi-groups.ts
@@ -352,7 +352,7 @@ export const BracketGroupsAbi = [
         "type": "uint32"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -386,7 +386,7 @@ export const BracketGroupsAbi = [
         "type": "uint32"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/packages/client/src/groups.ts
+++ b/packages/client/src/groups.ts
@@ -193,7 +193,7 @@ export class BracketGroupsUserClient extends BracketGroupsPublicClient {
     return this.walletClient.account.address;
   }
 
-  /** Create a public group (no password). */
+  /** Create a public group (no password). Creator is auto-joined (sends entry fee as value). */
   async createGroup(
     slug: string,
     displayName: string,
@@ -202,11 +202,11 @@ export class BracketGroupsUserClient extends BracketGroupsPublicClient {
   ): Promise<Hash> {
     return this.shieldedContract.twrite.createGroup(
       [slug, displayName, entryFee],
-      opts,
+      { value: entryFee, ...opts },
     );
   }
 
-  /** Create a password-protected group. Password is sbytes12 (shielded write). */
+  /** Create a password-protected group. Password is sbytes12 (shielded write). Creator is auto-joined. */
   async createGroupWithPassword(
     slug: string,
     displayName: string,
@@ -216,7 +216,7 @@ export class BracketGroupsUserClient extends BracketGroupsPublicClient {
   ): Promise<Hash> {
     return this.shieldedContract.write.createGroupWithPassword(
       [slug, displayName, entryFee, password],
-      opts,
+      { value: entryFee, ...opts },
     );
   }
 

--- a/packages/web/src/hooks/useGroups.ts
+++ b/packages/web/src/hooks/useGroups.ts
@@ -194,15 +194,17 @@ export function useGroups() {
     [groupsUser, trackGroup, refreshGroups],
   );
 
-  /** Create a public group. Tracks as admin. */
+  /** Create a public group. Creator is auto-joined. Tracks as admin. */
   const createGroup = useCallback(
     async (slug: string, displayName: string, entryFee: bigint) => {
-      if (!groupsUser) throw new Error("Wallet not connected");
+      if (!groupsUser || !groupsPublic) throw new Error("Wallet not connected");
       setIsLoading(true);
       setError(null);
       try {
         const hash = await groupsUser.createGroup(slug, displayName, entryFee);
-        // TODO: parse groupId from event logs once available
+        // Look up group by slug to get the ID and track it
+        const result = await groupsPublic.getGroupBySlug(slug);
+        trackGroup(result[0], { admin: true, slug, displayName, entryFee: entryFee.toString() });
         await refreshGroups();
         return hash;
       } catch (err) {
@@ -213,19 +215,21 @@ export function useGroups() {
         setIsLoading(false);
       }
     },
-    [groupsUser, refreshGroups],
+    [groupsUser, groupsPublic, trackGroup, refreshGroups],
   );
 
-  /** Create a password-protected group. Takes a human-readable passphrase. */
+  /** Create a password-protected group. Takes a human-readable passphrase. Creator is auto-joined. */
   const createGroupWithPassword = useCallback(
     async (slug: string, displayName: string, entryFee: bigint, passphrase: string) => {
-      if (!groupsUser) throw new Error("Wallet not connected");
+      if (!groupsUser || !groupsPublic) throw new Error("Wallet not connected");
       setIsLoading(true);
       setError(null);
       try {
         const password = passphraseToBytes12(passphrase);
         const hash = await groupsUser.createGroupWithPassword(slug, displayName, entryFee, password);
-        // TODO: parse groupId from event logs to trackGroup(groupId, { admin: true, password })
+        // Look up group by slug to get the ID and track it
+        const result = await groupsPublic.getGroupBySlug(slug);
+        trackGroup(result[0], { admin: true, passphrase, password, slug, displayName, entryFee: entryFee.toString() });
         await refreshGroups();
         return { hash, password };
       } catch (err) {
@@ -236,7 +240,7 @@ export function useGroups() {
         setIsLoading(false);
       }
     },
-    [groupsUser, refreshGroups],
+    [groupsUser, groupsPublic, trackGroup, refreshGroups],
   );
 
   /** Leave a group. */


### PR DESCRIPTION
## Summary
- **Contract**: `createGroup` and `createGroupWithPassword` now auto-join the creator as the first member with default name "CREATOR" (editable via `editEntryName`). Both functions are now `payable` — creator sends the group entry fee with the tx.
- **Client**: `BracketGroupsUserClient.createGroup` / `createGroupWithPassword` automatically pass `value: entryFee`.
- **Frontend**: `useGroups` hook now tracks newly created groups in localStorage immediately (resolves the TODO for parsing groupId).
- **Tests**: 39 BracketGroups tests updated/added including creator auto-join, name editing, and creation validation (no bracket, wrong fee, after deadline).

## Motivation
Creating a group required a separate `joinGroup` transaction afterward, which was annoying and easy to forget. Now it's a single transaction.

## Test plan
- [x] All 154 contract tests pass (39 BracketGroups)
- [x] Packages typecheck, lint, build, test pass
- [x] `scripts/ci.sh contracts` and `scripts/ci.sh packages` pass locally
- [ ] Manual test: create group with entry fee on testnet, verify creator auto-joined
- [ ] Manual test: edit creator name after group creation