### PR TITLE
Redeploy BracketGroups with auto-join-on-create

### DIFF
--- a/data/deployments.json
+++ b/data/deployments.json
@@ -2,7 +2,7 @@
   "2026": {
     "5124": {
       "marchMadness": "0x431188ca4dC5626551d813acdd2474B7f909D7CB",
-      "bracketGroups": "0x21994Eb609B798a51c000D31eb3e00ab6Dc94c7E",
+      "bracketGroups": "0xaDddc1fB51b771276B77c059a053153B7255280B",
       "bracketMirror": "0xdb9cc92Dcc367D34f55D2bc954C68A6e5B1f41e9"
     }
   }

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Redeploy BracketGroups with auto-join
+- **Deploy**: Redeployed BracketGroups to testnet (`0xaDddc1fB51b771276B77c059a053153B7255280B`) with auto-join-on-create feature. MarchMadness and BracketMirror unchanged.
+
 ### 2026-03-16 — Auto-join creator when creating a BracketGroups group
 - **Contract**: `createGroup` and `createGroupWithPassword` now auto-join the creator as the first member with default name "CREATOR". Both functions are now `payable` — creator sends the group entry fee (if any) with the transaction. Creator can update their name via `editEntryName`.
 - **Client**: `createGroup` / `createGroupWithPassword` in `BracketGroupsUserClient` now automatically send `value: entryFee`.

--- a/docs/prompts/cdai__redeploy-bracket-groups/1742140900-redeploy.txt
+++ b/docs/prompts/cdai__redeploy-bracket-groups/1742140900-redeploy.txt
@@ -1,0 +1,1 @@
+ok so this looks great. can you checkout to a fresh branch, deploy ONLY the group contract (use existing marchmadness) and, updat the deployments.json to have the right address


### PR DESCRIPTION
## Summary
- Redeployed BracketGroups to testnet with the auto-join-on-create feature from #123
- New address: `0xaDddc1fB51b771276B77c059a053153B7255280B`
- MarchMadness (`0x431188ca4dC5626551d813acdd2474B7f909D7CB`) and BracketMirror unchanged

**Depends on #123** — merge that first.

## Test plan
- [x] Deploy script succeeded
- [x] `deployments.json` updated
- [ ] Manual test: create group on testnet, verify creator auto-joined