### PR TITLE
Fix bracket picker clearing out-of-order picks (#121)

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Fix bracket picker clearing out-of-order picks (#121)
+- **UI fix**: `clearDownstream` in `useBracket` now only clears downstream picks that chose the team from the changed game's side of the bracket. Picks for the other feeder team are preserved, allowing users to fill in brackets out of order without losing later-round selections.
+
 ### 2026-03-16 — Redis integration for chain metadata
 - **Infra**: Replace flat JSON file storage with Redis for indexer and server.
 - **Indexer**: Writes all chain events (entries, tags, groups, mirrors) to Redis instead of `data/entries.json`.

--- a/docs/prompts/cdai__fix-bracket-picker-downstream-clearing/1742137200-fix-issue-121.txt
+++ b/docs/prompts/cdai__fix-bracket-picker-downstream-clearing/1742137200-fix-issue-121.txt
@@ -1,0 +1,3 @@
+hey fix this issue: https://github.com/SeismicSystems/march-madness/issues/121
+
+when you're done open a pr

--- a/packages/web/src/hooks/useBracket.ts
+++ b/packages/web/src/hooks/useBracket.ts
@@ -269,8 +269,9 @@ export function useBracket(walletAddress?: string | null) {
 export type UseBracketReturn = ReturnType<typeof useBracket>;
 
 /**
- * When a pick changes, clear any downstream games whose outcome
- * may have depended on the old winner.
+ * When a pick changes, clear downstream games whose picked winner
+ * came from the changed game's side of the bracket. Picks that chose
+ * a team from the *other* feeder game are unaffected and preserved.
  */
 function clearDownstream(
   picks: (boolean | null)[],
@@ -285,17 +286,30 @@ function clearDownstream(
     round++;
     roundSize = roundSize / 2;
   }
-  const posInRound = changedGameIndex - idx;
 
-  let nextGamePos = Math.floor(posInRound / 2);
+  let currentPos = changedGameIndex - idx;
   let nextGameRound = round + 1;
   let nextIdx = idx + roundSize;
 
   while (nextGameRound <= 5) {
     const nextRoundSize = roundSize / 2;
+    const nextGamePos = Math.floor(currentPos / 2);
     const gameIdx = nextIdx + nextGamePos;
+
+    // No pick here — nothing downstream depends on this path
+    if (picks[gameIdx] === null) break;
+
+    // The changed game feeds as team1 (even position) or team2 (odd position)
+    const feedsAsTeam1 = currentPos % 2 === 0;
+    const pickChoseChangedSide =
+      (feedsAsTeam1 && picks[gameIdx] === true) ||
+      (!feedsAsTeam1 && picks[gameIdx] === false);
+
+    // If the downstream pick chose the other team, it's unaffected — stop
+    if (!pickChoseChangedSide) break;
+
     picks[gameIdx] = null;
-    nextGamePos = Math.floor(nextGamePos / 2);
+    currentPos = nextGamePos;
     nextIdx += nextRoundSize;
     roundSize = nextRoundSize;
     nextGameRound++;


### PR DESCRIPTION
## Summary
- Fixes #121: bracket picker clears earlier-round selections when filled out of order
- `clearDownstream()` in `useBracket.ts` now tracks which side of the bracket the changed game feeds into each downstream game (team1 via even position, team2 via odd)
- Only clears a downstream pick if it chose the team from the changed game's side; picks for the other feeder team are preserved
- Users can now advance a team to the championship first, then fill in the rest of the bracket without losing those picks

## Test plan
- [ ] Open bracket picker, advance Duke (or any team) all the way to championship by clicking through each round
- [ ] Go back and fill in game 1 (the neighbor of Duke's R64 game) — Duke's later-round picks should be preserved
- [ ] Change Duke's R64 pick to the other team — all of Duke's downstream picks should be cleared (correct behavior)
- [ ] Fill bracket completely out of order (championship first, then work backwards) — all picks should stick
- [ ] Verify CI passes (contracts, packages, crates)