### PR TITLE
Remove POST /tournament-status endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,6 @@ Rust HTTP server (`crates/server`, default port 3000). Reads chain metadata from
 - `GET /mirrors/:slug` — mirror details by slug
 - `GET /mirrors/:slug/entries` — mirror entries (slug → bracket)
 - `GET /tournament-status` — tournament status JSON (from `data/{year}/men/status.json`, TTL cached)
-- `POST /tournament-status` — update tournament status (optional API key auth, rarely needed since `ncaa-feed` writes the file directly)
 - `GET /forecasts` — bracket win probabilities (from `data/{year}/men/forecasts.json`, written by forecaster crate)
 - `GET /health` — health check
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -28,10 +28,6 @@ struct Cli {
     /// Path to the forecasts JSON file (from forecaster crate).
     #[arg(long, default_value = "data/2026/men/forecasts.json")]
     forecasts_file: PathBuf,
-
-    /// API key for POST /tournament-status. Read from TOURNAMENT_API_KEY env var if not set.
-    #[arg(long, env = "TOURNAMENT_API_KEY")]
-    api_key: Option<String>,
 }
 
 #[tokio::main]
@@ -45,7 +41,6 @@ async fn main() -> eyre::Result<()> {
         cli.tournament_status_file.clone(),
         cli.forecasts_file.clone(),
         Duration::from_secs(5),
-        cli.api_key.clone(),
     )
     .await?;
 
@@ -59,10 +54,7 @@ async fn main() -> eyre::Result<()> {
         .route("/entries", get(routes::get_entries))
         .route("/entries/{address}", get(routes::get_entry))
         .route("/stats", get(routes::get_stats))
-        .route(
-            "/tournament-status",
-            get(routes::get_tournament_status).post(routes::post_tournament_status),
-        )
+        .route("/tournament-status", get(routes::get_tournament_status))
         .route("/forecasts", get(routes::get_forecasts))
         // Group routes
         .route("/groups", get(routes::get_groups))

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::Serialize;
 
@@ -94,35 +94,6 @@ pub async fn get_forecasts(State(state): State<AppState>) -> impl IntoResponse {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "failed to read forecasts",
-            )
-                .into_response()
-        }
-    }
-}
-
-/// POST /tournament-status — update tournament status JSON (requires API key).
-pub async fn post_tournament_status(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Json(body): Json<serde_json::Value>,
-) -> impl IntoResponse {
-    let auth = headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    let key = auth.strip_prefix("Bearer ").unwrap_or(auth);
-    if !state.check_api_key(key) {
-        return (StatusCode::UNAUTHORIZED, "invalid or missing API key").into_response();
-    }
-
-    match state.set_tournament_status(body).await {
-        Ok(()) => (StatusCode::OK, "updated").into_response(),
-        Err(e) => {
-            tracing::error!("failed to write tournament status: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to write tournament status",
             )
                 .into_response()
         }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -23,7 +23,6 @@ struct Inner {
     forecasts_path: PathBuf,
     forecasts_cache: RwLock<CachedJson>,
     ttl: Duration,
-    api_key: Option<String>,
 }
 
 struct CachedJson {
@@ -75,7 +74,6 @@ impl AppState {
         tournament_status_path: PathBuf,
         forecasts_path: PathBuf,
         ttl: Duration,
-        api_key: Option<String>,
     ) -> Result<Self> {
         let url = std::env::var("REDIS_URL").unwrap_or_else(|_| DEFAULT_REDIS_URL.to_string());
         let client = redis::Client::open(url.as_str())
@@ -100,7 +98,6 @@ impl AppState {
                     fetched_at: expired,
                 }),
                 ttl,
-                api_key,
             }),
         })
     }
@@ -310,23 +307,6 @@ impl AppState {
         Ok(data)
     }
 
-    pub async fn set_tournament_status(&self, value: serde_json::Value) -> Result<()> {
-        let path = self.inner.tournament_status_path.clone();
-        let data = value.clone();
-        tokio::task::spawn_blocking(move || -> Result<()> {
-            let contents = serde_json::to_string_pretty(&data)?;
-            std::fs::write(&path, contents)?;
-            Ok(())
-        })
-        .await??;
-
-        let mut cache = self.inner.tournament_status_cache.write().await;
-        cache.data = value;
-        cache.fetched_at = Instant::now();
-
-        Ok(())
-    }
-
     pub async fn get_forecasts(&self) -> Result<serde_json::Value> {
         {
             let cache = self.inner.forecasts_cache.read().await;
@@ -352,13 +332,6 @@ impl AppState {
         cache.fetched_at = Instant::now();
 
         Ok(data)
-    }
-
-    pub fn check_api_key(&self, key: &str) -> bool {
-        match &self.inner.api_key {
-            Some(expected) => key == expected,
-            None => false,
-        }
     }
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,25 +10,6 @@ The server proxies `/api/*` to the Rust server on port 3000.
 
 Returns the current tournament status. No auth required.
 
-### `POST /api/tournament-status`
-
-Update the tournament status. Optional API key auth (rarely needed — `ncaa-feed` writes the file directly on the same machine).
-
-```
-POST https://brackets.seismictest.net/api/tournament-status
-Authorization: Bearer <key>  (optional, if --api-key is set)
-Content-Type: application/json
-```
-
-#### curl example
-
-```bash
-curl -X POST https://brackets.seismictest.net/api/tournament-status \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d @tournament-status.json
-```
-
 ### `GET /api/entries`
 
 Returns all bracket entries (address → bracket hex + name). No auth required.
@@ -73,7 +54,7 @@ Returns per-bracket win probabilities (written by the forecaster crate). No auth
 
 ## Tournament Status Schema
 
-The POST body must be a JSON object with this shape:
+The tournament status JSON file (`data/{year}/men/status.json`, written by `ncaa-feed`) has this shape:
 
 ```jsonc
 {
@@ -221,9 +202,6 @@ cargo run --bin march-madness-server
 
 # Custom port
 cargo run --bin march-madness-server -- --port 3000
-
-# With optional API key for POST endpoint (not needed if ncaa-feed runs locally)
-cargo run --bin march-madness-server -- --api-key your-secret
 ```
 
 ## Running the Forecaster
@@ -244,36 +222,3 @@ cargo run --release --bin march-madness-forecaster -- \
 
 The forecaster reads `entries.json` + `data/2026/men/status.json` + `data/2026/men/tournament.json`, runs 100k Monte Carlo forward simulations, and writes `data/2026/men/forecasts.json`. The server will pick up the new file within 5 seconds (TTL cache).
 
-## Using the Rust Library
-
-Add to your `Cargo.toml`:
-
-```toml
-[dependencies]
-seismic-march-madness = { git = "https://github.com/SeismicSystems/march-madness.git", path = "crates/seismic-march-madness" }
-serde_json = "1"
-```
-
-Then construct and POST the `TournamentStatus`:
-
-```rust
-use seismic_march_madness::{TournamentStatus, GameStatus, GameState, GameScore};
-
-let status = TournamentStatus {
-    games: vec![
-        GameStatus {
-            game_index: 0,
-            status: GameState::Final,
-            score: Some(GameScore { team1: 82, team2: 55 }),
-            winner: Some(true),
-            team1_win_probability: None,
-        },
-        // ... 62 more
-    ],
-    team_reach_probabilities: Some(reach_map),
-    updated_at: Some("2026-03-20T18:30:00Z".to_string()),
-};
-
-let json = serde_json::to_string_pretty(&status).unwrap();
-// POST json to https://brackets.seismictest.net/api/tournament-status
-```

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Remove POST /tournament-status endpoint
+- **Server**: Removed `POST /tournament-status` endpoint, `--api-key` CLI flag, and `TOURNAMENT_API_KEY` env var. The `ncaa-feed` crate writes `status.json` directly; the server only needs to serve it via GET.
+- **Docs**: Updated `docs/api.md` and `CLAUDE.md` to reflect removal.
+
 ### 2026-03-16 — Add deploy configuration
 - **Deploy**: Added `deploy/` directory with nginx, supervisor, and Redis setup for production.
 - **nginx.conf**: Static frontend serving + reverse proxy `/api/*` to Rust server on port 3000.

--- a/docs/prompts/cdai__remove-post-tournament-status/1742083200-remove-post-tournament-status.txt
+++ b/docs/prompts/cdai__remove-post-tournament-status/1742083200-remove-post-tournament-status.txt
@@ -1,0 +1,13 @@
+Remove the `POST /tournament-status` endpoint entirely from the codebase. This includes:
+
+1. The route registration in `crates/server/src/main.rs`
+2. The handler function `post_tournament_status` in `crates/server/src/routes.rs`
+3. The `set_tournament_status` method in `crates/server/src/state.rs`
+4. The `api_key` field from the CLI struct in `crates/server/src/main.rs` (and remove passing it to AppState if applicable)
+5. The `api_key` field from AppState/inner state struct
+6. Any documentation referencing this endpoint in `docs/api.md`, `CLAUDE.md`
+7. Remove the `TOURNAMENT_API_KEY` env var reference from the server CLI
+
+After removing, run `./scripts/ci.sh crates` to verify everything compiles and passes.
+
+Then stage all changed files, commit with message "Remove POST /tournament-status endpoint (ncaa-feed writes directly)", and push to the current branch.


### PR DESCRIPTION
## Summary
- Removed `POST /tournament-status` route, handler (`post_tournament_status`), and backing method (`set_tournament_status`) from the server crate
- Removed `--api-key` CLI flag and `TOURNAMENT_API_KEY` env var from the server
- Removed `api_key` field from `AppState`/`Inner` and the `check_api_key` method
- Updated `docs/api.md` and `CLAUDE.md` to reflect removal

The `ncaa-feed` crate writes `data/{year}/men/status.json` directly on the same machine; the server only needs to serve it via `GET`.

## Test plan
- [x] `./scripts/ci.sh crates` passes (build, test, fmt, clippy)