### PR TITLE
Fix NCAA schedule API

### DIFF
--- a/crates/ncaa-api/src/schedule.rs
+++ b/crates/ncaa-api/src/schedule.rs
@@ -33,12 +33,13 @@ pub async fn fetch_schedule(
 
     let entries = gql
         .data
-        .and_then(|d| d.schedule)
+        .and_then(|d| d.schedules)
+        .and_then(|s| s.games)
         .ok_or_else(|| NcaaApiError::Parse("schedule response missing data".into()))?;
 
     let mut dates = Vec::new();
     for entry in entries {
-        if entry.number_of_games > 0 {
+        if entry.count > 0 {
             dates.push(ContestDate::parse(&entry.contest_date)?);
         }
     }
@@ -54,19 +55,21 @@ mod tests {
     fn test_parse_schedule_response() {
         let json = r#"{
             "data": {
-                "schedule": [
-                    {"contestDate": "2026/03/15", "numberOfGames": 8},
-                    {"contestDate": "2026/03/16", "numberOfGames": 8},
-                    {"contestDate": "2026/03/17", "numberOfGames": 0}
-                ]
+                "schedules": {
+                    "games": [
+                        {"contestDate": "03/15/2026", "count": 8},
+                        {"contestDate": "03/16/2026", "count": 8},
+                        {"contestDate": "03/17/2026", "count": 0}
+                    ]
+                }
             }
         }"#;
 
         let gql: ScheduleGqlResponse = serde_json::from_str(json).unwrap();
-        let entries = gql.data.unwrap().schedule.unwrap();
+        let entries = gql.data.unwrap().schedules.unwrap().games.unwrap();
         let dates: Vec<ContestDate> = entries
             .into_iter()
-            .filter(|e| e.number_of_games > 0)
+            .filter(|e| e.count > 0)
             .map(|e| ContestDate::parse(&e.contest_date).unwrap())
             .collect();
 

--- a/crates/ncaa-api/src/types.rs
+++ b/crates/ncaa-api/src/types.rs
@@ -228,6 +228,8 @@ impl From<RawTeam> for Team {
 }
 
 /// Schedule API response — used to get today's contest date.
+///
+/// NCAA API format: `{ "data": { "schedules": { "games": [ { "contestDate": "MM/DD/YYYY", "count": N }, ... ] } } }`
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ScheduleGqlResponse {
     pub data: Option<ScheduleData>,
@@ -235,8 +237,12 @@ pub(crate) struct ScheduleGqlResponse {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ScheduleData {
-    #[serde(rename = "schedule")]
-    pub schedule: Option<Vec<ScheduleEntry>>,
+    pub schedules: Option<ScheduleWrapper>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ScheduleWrapper {
+    pub games: Option<Vec<ScheduleEntry>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -245,7 +251,7 @@ pub(crate) struct ScheduleEntry {
     #[serde(default)]
     pub contest_date: String,
     #[serde(default)]
-    pub number_of_games: i32,
+    pub count: i32,
 }
 
 // ── Sport code ──────────────────────────────────────────────────────
@@ -350,9 +356,10 @@ pub struct ContestDate {
 }
 
 impl ContestDate {
-    /// Parse from "YYYY/MM/DD" format.
+    /// Parse from "YYYY/MM/DD" or "MM/DD/YYYY" format (NCAA API uses both).
     pub fn parse(s: &str) -> Result<Self, NcaaApiError> {
         let date = chrono::NaiveDate::parse_from_str(s, "%Y/%m/%d")
+            .or_else(|_| chrono::NaiveDate::parse_from_str(s, "%m/%d/%Y"))
             .map_err(|e| NcaaApiError::Parse(format!("invalid contest date '{s}': {e}")))?;
         Ok(Self { date })
     }

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Fix NCAA schedule API breaking change
+- **ncaa-api**: Updated schedule response parsing for NCAA API format change: `data.schedule` → `data.schedules.games`, `numberOfGames` → `count`, date format `YYYY/MM/DD` → `MM/DD/YYYY`.
+- **ncaa-api**: `ContestDate::parse` now accepts both `YYYY/MM/DD` and `MM/DD/YYYY` formats.
+
 ### 2026-03-16 — Remove POST /tournament-status endpoint
 - **Server**: Removed `POST /tournament-status` endpoint, `--api-key` CLI flag, and `TOURNAMENT_API_KEY` env var. The `ncaa-feed` crate writes `status.json` directly; the server only needs to serve it via GET.
 - **Docs**: Updated `docs/api.md` and `CLAUDE.md` to reflect removal.

--- a/docs/prompts/cdai__fix-ncaa-schedule-api/1742140800-investigate-schedule-error.txt
+++ b/docs/prompts/cdai__fix-ncaa-schedule-api/1742140800-investigate-schedule-error.txt
@@ -1,0 +1,32 @@
+look into this:
+
+ubuntu@clown-beatdown:~/march-madness$ tail -f /var/log/supervisor/ncaa-feed.err.log -n 100
+Error: failed to fetch schedule
+
+Caused by:
+    failed to parse API response: schedule response missing data
+
+Location:
+    crates/ncaa-feed/src/main.rs:157:10
+Error: failed to fetch schedule
+
+Caused by:
+    failed to parse API response: schedule response missing data
+
+Location:
+    crates/ncaa-feed/src/main.rs:157:10
+Error: failed to fetch schedule
+
+Caused by:
+    failed to parse API response: schedule response missing data
+
+Location:
+    crates/ncaa-feed/src/main.rs:157:10
+Error: failed to fetch schedule
+
+Caused by:
+    failed to parse API response: schedule response missing data
+
+Location:
+    crates/ncaa-feed/src/main.rs:157:10
+^C

--- a/docs/prompts/cdai__fix-ncaa-schedule-api/1742140801-open-pr.txt
+++ b/docs/prompts/cdai__fix-ncaa-schedule-api/1742140801-open-pr.txt
@@ -1,0 +1,1 @@
+yes open a pr


### PR DESCRIPTION
## Note
Pretty sure this wasn't a breaking change like claude claims, he probably just broke the code lol

## Summary
- NCAA changed their schedule GraphQL response: `data.schedule` → `data.schedules.games`, `numberOfGames` → `count`, date format `YYYY/MM/DD` → `MM/DD/YYYY`
- Updated `ScheduleData`/`ScheduleEntry` types and parsing in `ncaa-api` crate
- `ContestDate::parse` now accepts both old and new date formats

## Test plan
- [x] `cargo test -p ncaa-api` — all 11 tests pass
- [x] Local CI passes
- [ ] Deploy to prod and verify `ncaa-feed` no longer errors