### PR TITLE
Apply Seismic brand colors + fix bracket layout

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,15 +4,27 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-16 — Apply Seismic brand colors
+
+- **UI**: Replaced generic indigo/dark-blue theme with Seismic brand palette (mauve `#825A6D`, dark purple `#523542`, warm grays, muted gold `#A6924D`).
+- **UI**: Updated all `@theme` CSS variables in `index.css` for backgrounds, text, borders, accent, warning, and gold.
+- **UI**: Added `--color-dark-purple` theme variable for secondary accent.
+- **UI**: Replaced hardcoded `indigo-*`, `amber-*`, `yellow-*` Tailwind classes with semantic theme variables in GroupsSection, MirrorsSection, and HomePage.
+- **UI**: Updated Privy login modal accent color to mauve.
+- **Layout**: Fixed Final Four vertical centering and bracket region column alignment.
+
 ### 2026-03-16 — Fix NCAA schedule API breaking change
+
 - **ncaa-api**: Updated schedule response parsing for NCAA API format change: `data.schedule` → `data.schedules.games`, `numberOfGames` → `count`, date format `YYYY/MM/DD` → `MM/DD/YYYY`.
 - **ncaa-api**: `ContestDate::parse` now accepts both `YYYY/MM/DD` and `MM/DD/YYYY` formats.
 
 ### 2026-03-16 — Remove POST /tournament-status endpoint
+
 - **Server**: Removed `POST /tournament-status` endpoint, `--api-key` CLI flag, and `TOURNAMENT_API_KEY` env var. The `ncaa-feed` crate writes `status.json` directly; the server only needs to serve it via GET.
 - **Docs**: Updated `docs/api.md` and `CLAUDE.md` to reflect removal.
 
 ### 2026-03-16 — Add deploy configuration
+
 - **Deploy**: Added `deploy/` directory with nginx, supervisor, and Redis setup for production.
 - **nginx.conf**: Static frontend serving + reverse proxy `/api/*` to Rust server on port 3000.
 - **supervisor.conf**: Process management for `server`, `indexer`, and `ncaa-feed`.
@@ -21,9 +33,11 @@ All notable changes to this project. Every PR must add an entry here.
 - **Redis keys**: All Redis keys now prefixed with `mm:` (e.g. `mm:entries`, `mm:groups`) to namespace our data. Requires `FLUSHDB` or re-backfill after deploy.
 
 ### 2026-03-16 — Fix bracket picker clearing out-of-order picks (#121)
+
 - **UI fix**: `clearDownstream` in `useBracket` now only clears downstream picks that chose the team from the changed game's side of the bracket. Picks for the other feeder team are preserved, allowing users to fill in brackets out of order without losing later-round selections.
 
 ### 2026-03-16 — Redis integration for chain metadata
+
 - **Infra**: Replace flat JSON file storage with Redis for indexer and server.
 - **Indexer**: Writes all chain events (entries, tags, groups, mirrors) to Redis instead of `data/entries.json`.
 - **Indexer**: Contract addresses default to `data/deployments.json` if not specified via CLI.
@@ -35,33 +49,40 @@ All notable changes to this project. Every PR must add an entry here.
 - **Deps**: Added `redis` 0.27 with `tokio-comp` + `aio` features to workspace.
 
 ### 2026-03-16 — Gitignore broadcast directory
+
 - **Repo hygiene**: Removed committed `contracts/broadcast/` files and gitignored the entire directory. Broadcast logs are deployment artifacts that shouldn't be tracked.
 
 ### 2026-03-16 — Fix Kalshi trade log table alignment
+
 - **Bug fix**: `Side` column (`BUY`/`SELL`) wasn't respecting formatter width — `write!(f, "BUY")` bypasses padding; switched to `f.pad(s)`.
 - **Bug fix**: `Qty` column width was hardcoded to 4 but quantities can be 6+ digits; now computed dynamically via `log10`.
 - **Change**: Removed `¢` symbols from Price/Model/Edge columns and `$` from EV column — values are plain numbers, units are in the header.
 
 ### 2026-03-16 — Redeploy BracketGroups with auto-join
+
 - **Deploy**: Redeployed BracketGroups to testnet (`0xaDddc1fB51b771276B77c059a053153B7255280B`) with auto-join-on-create feature. MarchMadness and BracketMirror unchanged.
 
 ### 2026-03-16 — Auto-join creator when creating a BracketGroups group
+
 - **Contract**: `createGroup` and `createGroupWithPassword` now auto-join the creator as the first member with default name "CREATOR". Both functions are now `payable` — creator sends the group entry fee (if any) with the transaction. Creator can update their name via `editEntryName`.
 - **Client**: `createGroup` / `createGroupWithPassword` in `BracketGroupsUserClient` now automatically send `value: entryFee`.
 - **Frontend**: `useGroups` hook now tracks the newly created group in localStorage immediately after creation (looks up group ID by slug).
 - **Tests**: Updated all BracketGroups tests for auto-join behavior. Added tests for creator auto-join, name editing, and creation validation (no bracket, wrong fee, after deadline).
 
 ### 2026-03-16 — Prevent post-window BracketGroups scoring and add groups-only redeploy script
+
 - **Bug fix**: `BracketGroups.scoreEntry()` now reverts once the main scoring window has closed, even if the member was already scored on `MarchMadness`. This prevents group winner state from changing after claims are live.
 - **Tests**: Updated `BracketGroups.t.sol` to expect the closed-window revert for post-window group scoring.
 - **Deploy**: Added `DeployBracketGroups.s.sol` plus `scripts/redeploy-bracket-groups.sh` to deploy only a new `BracketGroups` contract against an existing `MarchMadness` address and update only the `bracketGroups` field in `data/deployments.json`.
 - **Tooling**: Added `bun run gen:abis`, backed by `scripts/generate-abis.ts`, to regenerate the checked-in client ABI snapshots directly from `ssolc` for `MarchMadness`, `BracketGroups`, and `BracketMirror`.
 
 ### 2026-03-16 — Simplify BracketMirror events to use slug instead of index
+
 - **Contract**: BracketMirror events (`EntryAdded`, `EntryRemoved`, `BracketUpdated`) now emit `slug` (string) instead of `entryIndex` (uint256). Slug is the stable identifier; array index is an implementation detail that changes on swap-and-pop.
 - **Deploy**: Added `DeployMirror.s.sol` forge script and `scripts/redeploy-mirror.sh` for redeploying only BracketMirror without touching MarchMadness or BracketGroups.
 
 ### 2026-03-16 — Fix submission deadline, reduce entry fee, redeploy contracts
+
 - **Bug fix**: Submission deadline was March 18 at Noon — corrected to **March 19 at 12:15 PM EST** (1773940500).
 - **Change**: Entry fee reduced from 1 ETH to **0.1 ETH** (testnet).
 - **Deploy**: Redeployed all contracts (MarchMadness, BracketGroups, BracketMirror) to testnet.
@@ -69,20 +90,25 @@ All notable changes to this project. Every PR must add an entry here.
 - **UX**: Entry fee display now says "testnet ETH" instead of just "ETH" to avoid confusion.
 
 ### 2026-03-16 — Remove dead Ethereum March Madness link from README
+
 - **Docs**: Remove dead link to `github.com/EthereumMarchMadness` from Credits section.
 
 ### 2026-03-16 — Shared SlugInput component, fix track-by-slug width
+
 - **Refactor**: Extract shared `SlugInput` component used by both join form and track-by-slug inputs — consistent sizing (`max-w-md`, `text-sm`, `py-1.5`).
 - **UX**: Track-by-slug input now matches join form width instead of stretching full-width.
 
 ### 2026-03-16 — Reset picks dialog hints about reloading on-chain bracket
+
 - **UX**: When user has an on-chain submission, the reset picks confirmation tells them they can reload it via "Load bracket" instead of "can't be undone".
 
 ### 2026-03-16 — Move Groups before Leaderboard in nav, track by slug
+
 - **UX**: Reordered nav bar so Groups appears before Leaderboard (both desktop and mobile).
 - **UX**: Replaced "Track by group ID" with "Track by slug" — looks up groups on-chain by slug instead of numeric ID, with error feedback.
 
 ### 2026-03-16 — Fix group join flow: entry fees, slug-first lookup, layout
+
 - **Bug fix**: Joining a group with a non-zero entry fee now correctly populates the transaction value. Previously always sent 0.
 - **UX**: Join flow now fetches group metadata before submitting the tx — validates group exists, checks wallet balance vs entry fee, and surfaces clear error messages.
 - **UX**: Slug is now the primary lookup method (unambiguous). Numeric input falls back to ID lookup, but slug is tried first — fixes the "42069" slug ambiguity.
@@ -91,55 +117,67 @@ All notable changes to this project. Every PR must add an entry here.
 - **Data**: Entry fee, slug, and display name are now stored in localStorage for joined groups.
 
 ### 2026-03-16 — Remove Groups and Mirrors sections from homepage
+
 - **Cleanup**: Removed GroupsSection and MirrorsSection from the homepage. Groups already have a dedicated `/groups` page. Mirrors will get a dedicated `/mirrors` page later (see issue).
 - **No functional change**: MirrorsSection component is kept in the codebase for future use.
 
 ### 2026-03-16 — Add passphrase field and invite links for private group joining
+
 - **Fix**: Private groups were impossible to join from the UI — no passphrase input existed. Added a passphrase field to the "Join a Group" form.
 - **UX**: When a slug resolves to a password-protected group, the passphrase field highlights and an error message prompts the user to enter the passphrase.
 - **Feature**: Shareable invite links for private groups (e.g., `/groups?slug=seismic-team&password=Quake100`). URL query params auto-populate the slug and passphrase fields. Invite link shown with copy button in the joined groups list for private groups.
 
 ### 2026-03-16 — Auto-fix sentinel bit on pasted hex brackets
+
 - **Behavior change**: When a user pastes a bracket hex with a missing sentinel bit (bit 63), the UI now automatically flips the bit to make it valid instead of loading the invalid hex as-is.
 - **UX**: Warning message now shows both the original pasted hex and the corrected hex so the user knows exactly what changed.
 
 ### 2026-03-16 — Make MirrorsSection discoverable with track/untrack UI
+
 - **Problem**: MirrorsSection was completely invisible — it only rendered when `mirrorIds.length > 0`, and the only way to add mirror IDs was programmatically via localStorage. No input, no form, no way for users to discover or use mirrors.
 - **Fix**: Always show MirrorsSection when a mirror contract is deployed. Added a "Track Mirror" form (accepts mirror ID or slug, validated on-chain) that saves to localStorage. Added "Untrack" button on each tracked mirror. Made `mirrorIds` state reactive so tracking/untracking updates the UI immediately.
 
 ### 2026-03-16 — Improve tag input width and submit button prominence on desktop
+
 - **UX**: Widened desktop tag input from `w-32` (8rem) to `w-52` (13rem) so longer display names like "DRAPPIS LOVELY CHALK" are fully visible.
 - **UX**: Added a vertical divider between the tag section and the submit/update button to visually separate the two actions.
 - **UX**: Made the submit/update button more prominent: larger padding (`px-6 py-2`), bigger text (`text-sm`), and a subtle accent ring (`ring-2 ring-accent/30`) so it's harder to miss.
 
 ### 2026-03-16 — Add Groups page, nav link, and create-group UI (Fixes #82)
+
 - **New page**: `/groups` route with dedicated `GroupsPage` — create groups (public or private with passphrase), set entry fee, auto-generated slug from display name.
 - **Navigation**: Added "Groups" link to both desktop nav bar and mobile hamburger menu in `Header.tsx`.
 - **Layout fix**: Constrained the join-group form in `GroupsSection` to `max-w-lg` with compact inline inputs on desktop, fixing the too-wide layout from issue #82.
 - **Discoverability**: Empty-state text now links to the Groups page so users know where to create groups.
 
 ### 2026-03-16 — Add confirmation dialog to Reset Picks button
+
 - **Frontend**: Clicking "Reset Picks" now shows a confirmation dialog ("This will clear all 63 picks. This can't be undone.") before clearing the bracket.
 - Added `@headlessui/react` for accessible, headless dialog/modal components styled with Tailwind.
 - New reusable `ConfirmDialog` component supports title, description, danger styling, and backdrop dismiss.
 
 ### 2026-03-16 — Remove redundant entry count from Header
+
 - **Cleanup**: Removed the "1 entry" / entry count badge from both desktop and mobile Header since each user only has one entry, making the display redundant.
 - Removed `entryCount` prop from `Header` component and removed the `useContract` hook from `App.tsx`.
 
 ### 2026-03-16 — Add copy/edit fan-out icons on hex display double-click
+
 - **Frontend**: Double-clicking the bracket hex value now fans out a copy icon and an edit (pencil) icon instead of immediately opening the hex input. Copy writes `bracket.encodedBracket` to clipboard with "Copied!" feedback; edit opens the existing hex input easter egg. Icons auto-collapse after 3 seconds or on click outside. Smooth `max-w` + opacity transition for the fan-out animation.
 
 ### 2026-03-16 — Fix bracket-sim ByteBracket encoding to match contract (MSB-first)
+
 - **Bug**: `bracket-sim` encoded game outcomes LSB-first (game 0 → bit 0) while `ByteBracket.sol` and the TS client use MSB-first (game 0 → bit 62, sentinel at bit 63). Hex strings from the sim decoded as "mostly 16 seeds win" in the UI because all bit positions were reversed.
 - **Root cause**: bracket-sim was self-consistent (LSB encoding + LSB scoring) so its internal roundtrip tests passed. The golden test vectors from issue #63 were never added to bracket-sim, so the cross-language mismatch went undetected.
 - **Fix**: Rewrote `to_byte_bracket_bb`, `from_byte_bracket_bb`, and `simulate_tournament_bb` to use MSB-first bit ordering via new `game_bit(i) = 1 << (62-i)` helper. `score_base_bb` now delegates to `seismic_march_madness::scoring::score_bracket` (direct port of on-chain `getBracketScore`). Added sentinel bit helpers (`set_sentinel`, `strip_sentinel`, `assert_sentinel`, `format_bb`, `parse_bb`). Added golden vector tests for encoding, scoring, and self-score to bracket-sim.
 - **Breaking**: All hex strings from bracket-sim are now `0x`-prefixed lowercase with sentinel bit set. Downstream consumers parsing bare uppercase hex must update.
 
 ### 2026-03-16 — Show encoded bracket hex when picks are complete
+
 - **Frontend**: The faint `0x` easter egg placeholder now shows the full encoded bracket hex (e.g. `0xad551133fffdfdff`) once all 63 picks are made. Slightly more visible than the empty `0x` hint. Still double-clickable to open the hex input for loading a different bracket.
 
 ### 2026-03-16 — Fix hex input paste not working
+
 - **Bug**: Pasting a bracket hex into the easter egg input did nothing — three root causes:
   1. Used `validateBracket()` which requires the sentinel bit (first nibble >= 8), but bracket hex from simulations/tools often omits it. The sentinel is only needed for on-chain submission, not for loading picks.
   2. `onBlur` handler captured stale `hexInput` state (always `""` from initial render), so any blur event immediately closed the input
@@ -147,39 +185,48 @@ All notable changes to this project. Every PR must add an entry here.
 - **Fix**: Replaced `validateBracket` with a simple `0x` + 16 hex char regex (no sentinel requirement). Added dedicated `onPaste` handler that reads directly from `clipboardData`. Fixed `onBlur` to check `hexRef.current.value` (DOM truth) instead of stale React state. Strips non-hex characters from pasted text.
 
 ### 2026-03-16 — Fix blank team names in bracket UI
+
 - **Bug**: Team names were blank because `BracketGame` rendered `team.abbrev` but `tournament.json` has no `abbrev` field — only `name`, `seed`, `region`. The value was `undefined`, rendering as empty text with no console error.
 - **Fix**: Made `abbrev` optional in the `Team` interface and added `team.abbrev ?? team.name` fallback in `BracketGame` so team names always display.
 
 ### 2026-03-16 — Bracket hex input easter egg
+
 - **Frontend**: Added a hidden hex input next to the Reset Picks button. A faint `0x` hint is visible but not editable — double-click it to unlock the input field. Type or paste a valid bytes8 bracket hex string to auto-fill all 63 picks instantly. Input closes on blur (if empty) or on successful load. Only visible before the deadline.
 
 ### 2026-03-16 — Skip First Four teams in Kalshi calibration
+
 - **Calibrate binary**: First Four teams (e.g. Texas, NC State) are now excluded from Kalshi market-making calibration. Kalshi has separate individual markets for each FF team, not a joint market for the bracket slot. Including them produced nonsense combined-name URLs and incorrect calibration signals. FF teams conservatively keep goose=0.
 - **Filtering**: FF teams are filtered out at the market-selection step (before orderbook fetching), avoiding wasted API calls. A safety guard in the orderbook-to-TeamOrderbook loop catches any that slip through.
 
 ### 2026-03-16 — Improve calibrator trade table alignment
+
 - **Trade log table**: Moved "Team" to the first column and "Side" to the second column for better readability. Added extra spacing between all columns so the table is less cramped.
 - **Rust fmt**: Fixed a pre-existing `rustfmt` issue in `calibrate.rs`.
 
 ### 2026-03-16 — Filter Kalshi calibration to tournament teams only
+
 - **Calibrate binary**: Markets are now filtered to only tournament teams (68) before fetching orderbooks, instead of fetching all ~150 markets per round. Cached orderbooks are also filtered by ticker on load.
 - **Mappings**: Added 6 missing Kalshi → NCAA name mappings to `data/mappings.toml` `[kalshi]` section: California Baptist, Hawai'i, LIU, Miami (OH), North Carolina St., Queens University.
 
 ### 2026-03-16 — Refresh ratings wrapper script
+
 - **New script** `scripts/refresh-ratings.sh` — convenience wrapper that scrapes KenPom ratings then runs Kalshi calibration in sequence. Defaults to 2-hour Kalshi cache TTL. Flags: `--cache-ttl` (seconds), `--no-kalshi` (kenpom only), `--no-kenpom` (calibrate only). Everything after `--` passes through to the calibrate binary. Step indicators `[1/2]`/`[2/2]` show progress; kenpom failure aborts before calibration.
 
 ### 2026-03-16 — Unsquish First Four teams in KenPom CSV
+
 - **Data**: `data/2026/men/kenpom.csv` now has one row per team (68 rows) instead of squishing First Four pairs into single rows with averaged metrics. Re-scraped from KenPom to get real individual ratings.
 - **Calibration**: New `save_kenpom_csv_with_goose()` in `bracket-sim/src/team.rs` preserves individual team metrics when writing calibrated goose values. For First Four teams, the slot's calibrated goose is applied to both individual team rows.
 - **Calibrate binary**: Updated to use `save_kenpom_csv_with_goose()` so calibration round-trips don't lose individual metrics.
 - **No changes needed** to `load_teams_from_json` — it already looked up individual FF team names and averaged them for simulation.
 
 ### 2026-03-16 — Multi-contract support: Groups, Mirrors across client, UI, and server (closes #65)
+
 - **Client library** (`packages/client`): Added ABIs (`abi-groups.ts`, `abi-mirror.ts`) and typed client wrappers for BracketGroups (`BracketGroupsPublicClient`, `BracketGroupsUserClient`) and BracketMirror (`BracketMirrorPublicClient`, `BracketMirrorAdminClient`). All group lifecycle methods exposed: createGroup, joinGroup, joinGroupWithPassword, leaveGroup, editEntryName, scoreEntry, collectWinnings, getGroupBySlug. Mirror methods: createMirror, addEntry, removeEntry, getEntryBySlug, etc. Updated barrel exports in `index.ts`.
 - **Server** (`crates/server`): Added `GET /api/groups` stub endpoint returning an empty list (placeholder for future public group registry).
 - **Web UI** (`packages/web`): Added `useGroups` hook with localStorage tracking of joined group IDs, group data refresh, and all group lifecycle methods. Added `GroupsSection` component displayed prominently on the home page for both pre- and post-lock states. Supports joining groups by ID or slug, leaving, editing display names, and tracking groups without on-chain join.
 
 ### 2026-03-16 — Embed tournament data in Rust lib via include_str! (closes #62)
+
 - **New module** `crates/seismic-march-madness/src/data.rs` — embeds tournament.json and kenpom.csv for all available years (2025, 2026 men's) at compile time via `include_str!`. Year-parameterized API: `TournamentData::embedded(year)`, `KenpomRatings::embedded(year)`, `tournament_json(year)`, `kenpom_csv(year)`. No default year — callers must be explicit.
 - **Updated `forecaster`** — `--tournament-file` is now optional; defaults to `TournamentData::embedded(2026)`.
 - **Updated `ncaa-feed`** — `--tournament-file` is now optional; defaults to `GameMapper::load_embedded(2026)`. Mapper takes year parameter.
@@ -187,22 +234,26 @@ All notable changes to this project. Every PR must add an entry here.
 - **Note**: `bracket-sim` is NOT updated — it continues reading from the filesystem. The embedded data is for external consumers who import `seismic-march-madness` without access to the repo's data files.
 
 ### 2026-03-16 — Cross-language golden test vectors for bracket encoding/scoring (closes #63)
+
 - **New file** `data/test-vectors/bracket-vectors.json` — 8 golden bracket vectors (all-chalk, all-upsets, mostly-chalk, cinderella run, alternating, split regions, single-bit-flip, region boundary), 16 scoring tests against two result sets, and 6 validation tests. Shared source of truth for TypeScript, Rust, and Solidity.
 - **Solidity tests** (`contracts/test/BracketVectors.t.sol`) — 30+ tests: self-score (192) for all 8 vectors, scoring against all-chalk and cinderella results (16 cross-checks), sentinel validation, e2e through MarchMadness contract (submit → results → score → payout), tied-winner pool splitting.
 - **TypeScript tests** — extended `bracket.test.ts` with golden vector encoding, roundtrip, and validation tests. Extended `scoring.test.ts` with golden vector scoring and self-score tests.
 - **Rust tests** — extended `crates/seismic-march-madness/src/scoring.rs` with golden vector encoding roundtrip, scoring, self-score, and validation tests.
 
 ### 2026-03-16 — Add @data/ TypeScript path alias for cleaner imports (closes #61)
+
 - Added `@data/*` path alias in `packages/web/tsconfig.json` (paths) and `packages/web/vite.config.ts` (resolve.alias) pointing to the repo-root `data/` directory.
 - Updated all `../../../../data/` relative imports in the web package to use `@data/` (constants.ts, tournament.ts).
 
 ### 2026-03-16 — Store bracket picks as hex in localStorage (closes #64)
+
 - **Changed** `loadPicks` / `savePicks` in `packages/web/src/hooks/useBracket.ts` to use compact storage formats instead of JSON boolean arrays (~300+ chars).
 - **Complete brackets** stored as canonical bytes8 hex string (18 chars, e.g. `0x8000000000000000`), using `encodeBracket` / `validateBracket` from the client library.
 - **Partial brackets** stored as `"partial:"` + 63-char string of `1`/`0`/`-` (71 chars total), preserving in-progress picks across page refreshes.
 - No migration needed — no real users yet; old JSON format is silently discarded on load.
 
 ### 2026-03-15 — Restructure data directory + centralized name mappings + First Four handling
+
 - **Data directory restructure**: Moved from `data/{year}/` to `data/{year}/men/` and `data/{year}/women/`. All per-gender data (tournament.json, kenpom.csv, status.json, mappings/) now lives under a gender subdirectory. Renamed `tournament-status.json` → `status.json`. Updated all CLI defaults, path helpers, frontend imports, and test references.
 - **New file** `data/mappings.toml` — centralized name mapping from sources (KenPom, Kalshi) to NCAA canonical names. Single source of truth for team name normalization.
 - **Updated `scrape_kenpom.py`** — loads name mappings from `data/mappings.toml`, writes KenPom data with NCAA canonical names. Uses `tournament.json` (not bracket.csv) for `--bracket-only` filtering, expanding First Four entries to include both individual teams.
@@ -210,10 +261,12 @@ All notable changes to this project. Every PR must add an entry here.
 - **Updated kalshi crate** — team name mapping now loads from centralized `data/mappings.toml` (removed `crates/kalshi/team_names.toml`).
 
 ### 2026-03-15 — Fix Kalshi orderbook parsing + calibration sensitivity
+
 - **Fix** Kalshi API now returns `orderbook_fp` (string dollar format) instead of `orderbook` (integer cents). `OrderbookResponse` is now a `#[serde(untagged)]` enum supporting both legacy and FP formats. FP values converted to integer cents for downstream use.
 - **Fix** Calibration `sensitivity` default changed from `2.0` to `0.001`. The old value was tuned for probability-based edges (small numbers), but real orderbook edges are in the thousands of dollars, causing goose values to slam to ±15 clamp on the first iteration.
 
 ### 2026-03-15 — Market-making calibrator (replaces CSV normalization pipeline)
+
 - **New module** `crates/kalshi/src/orderbook.rs` — market-making edge computation against Kalshi orderbooks. Walks top N orderbook levels to compute buy/sell edge per team/round. Includes trade log printer with Kalshi URLs.
 - **New types** in `crates/kalshi/src/types.rs` — `OrderbookLevel`, `Orderbook`, `TeamOrderbook`, `CachedOrderbooks`, `OrderbookResponse` for orderbook fetching and caching.
 - **New REST methods** in `crates/kalshi/src/rest.rs` — `get_orderbook(ticker, depth)` fetches per-market orderbook (converts NO bids to YES asks), `get_round_orderbooks()` batch fetches, plus orderbook-specific cache (`load_orderbook_cache`/`save_orderbook_cache`).
@@ -223,6 +276,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **Deleted** legacy CSV calibration mode (`calibration.rs`), normalization pipeline (`fair_value.rs`, `kalshi` binary fetch/watch commands), and pipeline scripts (`refresh.sh`, `fit_kenpom_model.py`). The `MarketDef` type was trimmed to remove normalization-only fields (`expected_sum`, `floor_prob`).
 
 ### 2026-03-15 — Bracket fetcher: auto-populate tournament.json from NCAA API
+
 - **New binary** `fetch-bracket` (in `ncaa-feed` crate) — queries the NCAA bracket API on Selection Sunday, extracts all 64 teams with seeds, regions, and Final Four pairings, then writes `data/{year}/tournament.json` and `data/{year}/mappings/ncaa-names.json`.
 - **New module** `ncaa_api::bracket` — fetches tournament bracket from NCAA's `sdataprod.ncaa.com` GraphQL API (persisted query `get_championship_ncaa`). Returns typed `Championship` with games, regions, and teams.
 - **Region ordering**: Automatically determines Final Four pairings by tracing `victorBracketPositionId` chains through regional finals → semifinals. Regions are ordered so indices 0,1 play each other and 2,3 play each other, matching the bracket encoding. For 2026: East-South, West-Midwest.
@@ -231,6 +285,7 @@ All notable changes to this project. Every PR must add an entry here.
 - Updated mapper tests to use real 2026 team names.
 
 ### 2026-03-15 — NCAA live score feed (closes #42, refs #43)
+
 - **New crate** `crates/ncaa-api` — NCAA basketball API client. Rate-limited HTTP client for the NCAA GraphQL API with 429 exponential backoff. Fetches scoreboard (live/final/upcoming games) and schedule data. Basketball-only (MBB/WBB, Division 1). Strong types: `ContestState` enum (Pre, Live{period,clock}, Final(overtimes), Other(raw)), `Period` enum, `ContestDate`, parsed scores/seeds.
 - **New crate** `crates/ncaa-feed` (`ncaa-feed` binary) — polls NCAA scoreboard, maps contests to bracket game indices (0-62), writes `data/2026/tournament-status.json`. Adaptive polling: pre-game (60s), active (configurable, default 1/s), auto-exit on tournament complete.
 - **Game mapping**: Uses `data/2026/mappings/ncaa-names.json` (NCAA nameShort → bracket position). R64 fast path computes game index directly. Later rounds derive matchups from decided game winners.
@@ -239,6 +294,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **16 new tests**: 9 in ncaa-api (scoreboard parsing, clock/period/overtime parsing, team scores, contest date, sport codes), 7 in ncaa-feed (mapper positions, feeder games, name resolution, feed state, poll intervals, seeding from existing status).
 
 ### 2026-03-15 — Use custom errors instead of require strings in all contracts (closes #39)
+
 - **MarchMadness.sol**: Replaced all ~15 `require(condition, "string")` statements with custom errors (`error ErrorName()` + `if (!condition) revert ErrorName()`). Errors with parameters: `IncorrectEntryFee(uint256 expected, uint256 actual)`.
 - **BracketGroups.sol**: Replaced all ~20 `require` statements with custom errors. Errors with parameters: `IncorrectEntryFee(uint256 expected, uint256 actual)`.
 - **BracketMirror.sol**: Replaced all ~10 `require` statements with custom errors.
@@ -246,17 +302,21 @@ All notable changes to this project. Every PR must add an entry here.
 - Errors defined per-contract (no shared error file) to keep things simple.
 
 ### 2026-03-15 — Improve desktop bracket vertical symmetry (closes #31)
+
 - Replaced hardcoded pixel spacing (`getVerticalSpacing`) with flex-based layout using `justify-around` and `items-stretch`. Each round column now stretches to the same height as the R64 column, and games within each round automatically center between their two feeder games from the previous round.
 - Top and bottom halves now use `items-stretch` for equal-height regions, producing a symmetric layout where the Final Four sits cleanly in the center.
 - Added `gap-2` minimum spacing between games for visual breathing room.
 
 ### 2026-03-15 — Upgrade seismic foundry to nightly-94eb5fc (closes #15)
+
 - Updated `sfoundry` pin in `mise.toml` from `nightly-08913bcc...` to `nightly-94eb5fc1...` (2026-03-14 release).
 
 ### 2026-03-15 — Make `score_base_bb` public in bracket-sim
+
 - Removed `#[cfg(test)]` and `pub(crate)` gate from `scoring::score_base_bb` so downstream consumers (e.g. the brackets pool-strategy repo) can use it directly instead of duplicating the function.
 
 ### 2026-03-15 — Sim: configurable pace dispersion + score-dist calibration tool (closes #41)
+
 - **Generalized pace distribution** in `crates/bracket-sim/src/game.rs` via `Game::sample_count(mean, d)` — a single dispersion ratio `d = variance/mean` controls the distribution family: d<1 uses binomial (underdispersed), d=1 uses Poisson, d>1 uses Gamma-Poisson/NB (overdispersed).
 - **Unified regulation and OT paths** — overtime now uses the same pace distribution as regulation instead of the old fixed-pace workaround. The dispersion parameter naturally scales variance with the mean.
 - **Calibrated default `DEFAULT_PACE_D = 0.3`** (underdispersed) via score-dist sweep against NCAA tournament empirical targets. At d=0.3 the simulated total-score stddev ≈ 20, closest to the empirical ~19.
@@ -267,10 +327,12 @@ All notable changes to this project. Every PR must add an entry here.
 - **New tests**: `sample_count_underdispersed`, `sample_count_overdispersed`, `sample_count_poisson_baseline`, `ot_has_pace_variance`.
 
 ### 2026-03-15 — Pipeline orchestration scripts
+
 - **New script** `scripts/refresh.sh` — runs the full KenPom/Kalshi ingestion pipeline (scrape KenPom, fetch raw Kalshi futures, fit anchor model, normalize Kalshi futures, calibrate goose values). Supports `--hours N` flag to control cache TTL (default 6 hours).
 - **CI: Python checks** — added `run_python` section to `scripts/ci.sh`: verifies `uv` deps install (`uv sync --frozen`) and runs `scrape_kenpom.py --help` as a smoke test. Wired into `all` and available as `./scripts/ci.sh python`.
 
 ### 2026-03-15 — Bracket simulation library and CLI
+
 - **New crate** `crates/bracket-sim` — Poisson-based NCAA tournament simulation engine with Bayesian metric updates. Ported from private `brackets` repo with rand 0.8->0.9 migration for edition 2024 compatibility.
 - **Library modules**: team loading/validation, game simulation (Poisson scoring + overtime), tournament orchestration, bracket encoding (ByteBracket u64 format), scoring systems, goose calibration against market odds.
 - **CLI binary** `sim` — runs Monte Carlo tournament simulations and prints round-by-round advancement probabilities for all 64 teams.
@@ -278,6 +340,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **Data files**: `data/2025/tournament.json`, `data/2026/tournament.json`, `data/{year}/kenpom.csv`.
 
 ### 2026-03-15 — BracketMirror + BracketGroups contracts
+
 - **New contract** `BracketMirror.sol` — standalone admin-managed off-chain bracket pool mirror. No money, no scoring, no composition with MarchMadness. Entries have unique slugs within a mirror for URL-friendly lookup (`getEntryBySlug`). Swap-and-pop removal.
 - **New contract** `BracketGroups.sol` — linked sub-groups composing with MarchMadness via `IMarchMadness` interface. Optional `sbytes12` password protection (shielded), optional entry fee with scoring + payout. Group IDs are `uint32`. Scoring delegates to `marchMadness.scoreBracket()` to avoid double work. Group struct uses `creator` (not `admin`). Join/leave gated by submission deadline.
 - **New interface** `IMarchMadness.sol` — minimal 6-function interface (`hasEntry`, `submissionDeadline`, `resultsPostedAt`, `scoreBracket`, `scores`, `isScored`) so BracketGroups only needs the deployed address.
@@ -287,6 +350,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **MarchMadness constructor**: Added `uint16 year` parameter — contracts are now self-describing for which tournament season they belong to. Deploy scripts pass year (production: `2026`, local: `YEAR` env var, default `2026`).
 
 ### 2026-03-15 — Kalshi odds ingestor crate
+
 - **New crate** `crates/kalshi` — standalone Kalshi prediction market odds ingestor for March Madness futures. Fetches round-by-round win probabilities from Kalshi's REST API and WebSocket stream.
 - **CLI binary** (`kalshi`) with two subcommands: `fetch` (one-shot REST fetch with file caching) and `watch` (live WebSocket NBBO streaming with periodic CSV writes).
 - **Fair value computation**: microprice from order book pressure (bid/ask sizes), with fallback to midpoint. Normalizes probabilities per round, backfills missing teams, and enforces cross-round monotonicity.
@@ -295,12 +359,14 @@ All notable changes to this project. Every PR must add an entry here.
 - Ported from the `brackets` repo with edition 2024 compatibility fixes (removed explicit `ref` in implicitly-borrowing patterns, collapsed `if` blocks per clippy).
 
 ### 2026-03-15 — Python KenPom scripts + UV project
+
 - **New**: `pyproject.toml` — UV Python project (`march-madness-scripts`) with dependencies for data pipeline scripts (cloudscraper, kenpompy, matplotlib, numpy, pandas, scikit-learn).
 - **New**: `scripts/scrape_kenpom.py` — scrapes KenPom ratings via kenpompy + cloudscraper (Cloudflare bypass), outputs `data/{YEAR}/kenpom.csv` (team, ortg, drtg, pace). Supports `--bracket-only` filtering and `--seeds-from` bracket CSV.
 - **New**: `scripts/fit_kenpom_model.py` — fits per-round logistic regression (degree-2 polynomial features, C=0.1 regularization) from KenPom stats to Kalshi market probabilities. Outputs `data/{YEAR}/kenpom_anchor_model.json` with model coefficients, scaler params, and anchor ranges. Generates fit quality plots to `data/{YEAR}/plots/`.
 - **Updated**: `.gitignore` — added `.venv/`, `data/*/plots/`, `__pycache__/`.
 
 ### 2026-03-15 — Bracket forecaster: forward Monte Carlo win probabilities
+
 - **New crate** `crates/forecaster` (`march-madness-forecaster`) — reads `data/entries.json` + `data/tournament-status.json` + `data/mens-2026.json`, runs forward Monte Carlo simulations (default 100k) to compute per-bracket win probabilities, writes `data/forecasts.json`.
 - **Forward simulation**: resolves games round-by-round. Decided games use known winner, live games use in-game `team1WinProbability`, upcoming games derive P(A beats B) from `teamReachProbabilities` via Bradley-Terry: `P(A wins) = reach[A][r+1] / (reach[A][r+1] + reach[B][r+1])`. Later-round matchups depend on who actually advanced in each simulation — no independent coin-flip approximation.
 - **Renamed** `crates/common` → `crates/seismic-march-madness` (`seismic-march-madness` crate). This is the shared library for types, scoring, simulation, and tournament helpers — importable by 3rd-party data providers.
@@ -314,6 +380,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **Server port**: Default port changed from 3001 → 3000 (matches nginx proxy config at `brackets.seismictest.net`).
 
 ### 2026-03-15 — Tournament Live UI: leaderboard, bracket viewer, scoring
+
 - **Client library**: Ported ByteBracket scoring algorithm from Solidity to TypeScript BigInt (`scoring.ts`). Added `scoreBracket()` (full), `scoreBracketPartial()` (in-progress with max possible), `getScoringMask()`, `popcount()`, `pairwiseOr()`.
 - **Types**: Added shared types in `packages/client/src/types.ts` — `TournamentStatus`, `GameStatus`, `EntryRecord`, `EntryIndex`, `PartialScore`.
 - **Rust server**: Added `GET /api/tournament-status` (serves `data/tournament-status.json` with TTL cache) and `POST /api/tournament-status` (API key auth via `TOURNAMENT_API_KEY` env var or `--api-key` flag) for external data sources to push status updates.
@@ -326,33 +393,40 @@ All notable changes to this project. Every PR must add an entry here.
 - **Hooks**: `useTournamentStatus` (polls /api/tournament-status every 30s), `useEntries` (polls /api/entries every 30s), `useReadOnlyBracket` (compute GameSlot[] from hex string).
 
 ### 2026-03-15 — Desktop bracket layout redesign
+
 - **Bracket convergence**: Fixed double-reversal bug in `BracketRegion` — right-side regions (West, Midwest) now correctly flow inward toward the center where the champion is crowned, matching standard bracket app convention.
 - **Submit panel**: Redesigned as a compact horizontal bar on desktop (mobile layout unchanged). Progress, status, entry fee, tag input, and submit button all in one thin row.
 - **Removed scoreboard footer**: Removed the placeholder scoreboard section — will revisit later.
 
 ### 2026-03-15 — Fix Buffer polyfill for Privy signing
+
 - **Root cause**: Privy's embedded wallet signer calls `Buffer.from()` internally when signing EIP-712 typed data. `Buffer` is a Node.js global not available in browsers.
 - Added `buffer` package as devDependency
 - Added `Buffer` polyfill in `main.tsx` before any other imports
 - Added `global: "globalThis"` to Vite config
 
 ### 2026-03-15 — Fix [object Object] in error display
+
 - Error extraction now JSON.stringifies all non-string values so object details render as readable JSON instead of `[object Object]`
 - Unrecognized error objects without standard fields are dumped in full
 
 ### 2026-03-15 — Mobile header dropdown + better error surfacing
+
 - **Header**: On mobile, replaced inline buttons (Faucet, address, Connect/Disconnect) with a hamburger dropdown menu to prevent text overlap on small screens. Desktop layout unchanged.
 - **Error handling**: Added `extractErrorMessage` helper that walks the error cause chain to surface the real error from Privy/viem instead of showing generic "An error has occurred" messages. Errors now show in a scrollable container on mobile.
 
 ### 2026-03-14 — Add `/checklist` skill
+
 - Added `.claude/skills/checklist/SKILL.md` — user-invocable skill that mirrors the CLAUDE.md rules checklist, for quick verification before pushing or opening PRs
 - Added sync note to CLAUDE.md: any changes to the rules checklist must also be reflected in the skill
 
 ### 2026-03-14 — Bracket spacing + sbytes8 fix (seismic-viem PR)
+
 - **Bracket spacing**: Increased R64 vertical gap from 2px to 8px (desktop) / 6px (mobile), and bumped later rounds proportionally. Games no longer appear jammed together.
 - **sbytes8 bug**: Root-caused to seismic-viem v1.1.1 missing `sbytes*` in `remapSeismicAbiInputs`. Fix submitted upstream: SeismicSystems/seismic#117 (v1.1.2). Will update dep when published.
 
 ### 2026-03-14 — Lazy signed read + hasEntry contract function
+
 - **Contract**: Added `mapping(address => bool) public hasEntry` — set to `true` on `submitBracket()`. Allows anyone to check if an address has submitted without a signed read.
 - **ABI + Client**: Added `getHasEntry(address)` to `MarchMadnessPublicClient`
 - **Frontend**: On login, calls `hasEntry(address)` (public, no signing) to check submission status. The signed read (`getMyBracket`) is now only triggered when user clicks "Load my bracket" button.
@@ -361,6 +435,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **Redeployed** contract to testnet: `0xD1cA8aDfdaE872D44Af5aACf8a9EfE7493c606cf`
 
 ### 2026-03-14 — UX improvements: faucet, localStorage picks, multi-round advancing
+
 - **Faucet link**: added "Faucet" link in header (opens in new tab), plus a prominent `FaucetBanner` when connected with 0 ETH balance — shows address with copy button and "Get Testnet ETH" link
 - **Copyable address**: connected wallet address is shown in header and clickable to copy on both mobile and desktop
 - **Balance check**: `useContract` now fetches wallet ETH balance; App shows faucet banner when balance is 0
@@ -369,6 +444,7 @@ All notable changes to this project. Every PR must add an entry here.
 - Added `FAUCET_URL` constant
 
 ### 2026-03-14 — Fix deadline timestamp + redeploy contract
+
 - **Bug**: `SUBMISSION_DEADLINE` was `1742313600` (March 18, **2025**) instead of `1773853200` (March 18, **2026**). This caused the app to show "Brackets are locked" a year early.
 - Fixed timestamp in `constants.ts` and `MarchMadness.s.sol`
 - Redeployed contract to testnet: `0x9cf71ec28D89330fD537b9131752ADA8157622b5`
@@ -376,6 +452,7 @@ All notable changes to this project. Every PR must add an entry here.
 - **Privy connect**: configured Privy app with correct app ID, enabled all social login methods, and added `brackets.seismictest.net` to allowed domains in Privy dashboard
 
 ### 2026-03-14 — Mobile-friendly web app (closes #10)
+
 - Added `useIsMobile` hook (viewport < 768px detection via matchMedia)
 - BracketView: mobile renders tabbed region selector (East/West/South/Midwest/Final Four) instead of 1400px-wide horizontal layout
 - BracketGame: added `mobile` prop — tighter padding (px-1.5, py-0.5), smaller text (11px), smaller min-widths (72-80px) so a full region fits on small screens
@@ -386,12 +463,14 @@ All notable changes to this project. Every PR must add an entry here.
 - Tested down to 320px width (iPhone SE) — each region tab fits without horizontal scroll
 
 ### 2026-03-14 — Deploy MarchMadness to Seismic testnet (gcp-2)
+
 - Deployed MarchMadness contract to Seismic testnet (chain 5124): `0xEbc32b5436D7DaA0e5b79431074242a29890364b`
 - Entry fee: 1 ETH, submission deadline: March 18, 2026 12:00 PM EST
 - Updated `data/deployments.json` with testnet contract address
 - Added `contracts/broadcast/` to `.gitignore` (sforge broadcast artifacts)
 
 ### 2026-03-14 — Single .env at repo root + testnet deploy script
+
 - Consolidated all env vars into a single `.env` file at repo root (was also in `contracts/.env.example`)
 - Added `.env` to root `.gitignore` — the file contains a real testnet deployer private key
 - Created `.env.example` with documented placeholders for all env vars (deployment, frontend, local dev)
@@ -408,18 +487,21 @@ All notable changes to this project. Every PR must add an entry here.
 - Updated CLAUDE.md, README.md, docs/technical.md with environment documentation
 
 ### 2026-03-14 — PR #8 Review: Restructure tests package to localdev (`packages/localdev`)
+
 - Renamed `packages/tests` to `packages/localdev` (`@march-madness/localdev`) — this is primarily a local dev tool, not just tests
 - Moved `integration.test.ts` from `src/` to `test/` directory (at same level as `src/`)
 - Added shorthand bun scripts to root `package.json`: `bun p:pre`, `bun p:post`, `bun p:grading`
 - Updated all references across CLAUDE.md, README.md, docs/technical.md, packages/mise.toml
 
 ### 2026-03-14 — PR #8 Review: Refactor tests to use client library (`packages/tests`)
+
 - Refactored `populate.ts` and `integration.test.ts` to use `MarchMadnessPublicClient`, `MarchMadnessUserClient`, and `MarchMadnessOwnerClient` from `@march-madness/client` instead of raw `wallet.writeContract()` / `publicClient.readContract()` calls
 - Added factory functions to `utils.ts`: `createMMPublicClient()`, `createMMUserClient()`, `createMMOwnerClient()`
 - Removed local `ENTRY_FEE` constant from `utils.ts` — now re-exported from `@march-madness/client`
 - Raw wallet calls kept only where client library cannot express the test (wrong entry fee, cross-user bracket read before deadline, non-owner submitResults)
 
 ### 2026-03-14 — Integration Tests & Local Dev Population (`packages/tests`)
+
 - Added `src/utils.ts` — test utilities: random/chalky bracket generation, sforge deploy, sanvil process spawning, anvil account loader, seismic-viem client helpers, time manipulation (evm_increaseTime + evm_mine)
 - Added `src/integration.test.ts` — full end-to-end test suite (expects sanvil already running): deploy via sforge, concurrent bracket submission, tags, updates, signed read (own bracket before deadline), fast-forward past deadline, transparent read, results posting, scoring, payout collection with balance verification
 - Added `src/populate.ts` — local dev population script that spawns sanvil itself, deploys via sforge, and populates state:
@@ -433,11 +515,13 @@ All notable changes to this project. Every PR must add an entry here.
 - Updated `packages/mise.toml` to include tests package in typecheck, lint, and build tasks
 
 ### 2026-03-14 — PR #5 Review Fixes
+
 - provider.rs: Support both SeismicReth (prod) and SeismicFoundry (sanvil) via `IndexerProvider` enum and `--network` CLI flag
 - ci.sh: Missing `Cargo.toml` or `cargo` now fails CI instead of silently skipping
 - main.rs: Renamed `Check` enum variant to `SanityCheck` (CLI subcommand remains `check` via `#[command(name = "check")]`)
 
 ### 2026-03-14 — Rust Indexer Binary (`crates/indexer`)
+
 - Built `march-madness-indexer` — event indexer for MarchMadness contract on Seismic
 - Four subcommands via clap: `listen` (live polling), `backfill` (historical scan), `reveal` (post-deadline bracket reading), `check` (sanity check vs on-chain count)
 - Uses seismic-alloy provider (`SeismicUnsignedProvider` via `SeismicProviderBuilder`) for all RPC calls
@@ -450,14 +534,17 @@ All notable changes to this project. Every PR must add an entry here.
 - Updated CI scripts and GitHub workflow to use root workspace
 
 ### 2026-03-14 — PR #6 Review Fixes (`packages/web`)
+
 - Changed address truncation from first 8 + last 8 to first 4 + last 4 chars (e.g., `0x1234...abcd`)
 - Replaced Inter font with Fira Mono as the global font (Google Fonts link + CSS body rule)
 
 ### 2026-03-14 — Max Privy Login Methods (`packages/web`)
+
 - Expanded loginMethods from [twitter, discord] to all 15 Privy-supported methods: wallet, email, sms, google, twitter, discord, github, linkedin, spotify, instagram, tiktok, apple, farcaster, telegram, passkey
 - Removed disableAllExternalWallets restriction to support MetaMask and other external wallets with wallet login method
 
 ### 2026-03-14 — Web Frontend Refactor: Use Client Library (`packages/web`)
+
 - Deleted hand-written `src/lib/abi.ts` — ABI now comes from `@march-madness/client`
 - Refactored `useContract` hook to use `MarchMadnessPublicClient` (transparent reads) and `MarchMadnessUserClient` (shielded writes, signed reads) from client library
 - Replaced manual `walletClient.writeContract()` / `walletClient.readContract()` calls with client library methods (`mmUser.submitBracket()`, `mmUser.getMyBracket()`, etc.)
@@ -465,6 +552,7 @@ All notable changes to this project. Every PR must add an entry here.
 - Bracket encoding already used `encodeBracket` from client library (no change needed)
 
 ### 2026-03-14 — Web Frontend (`packages/web`)
+
 - Built React frontend with full 64-team bracket selection UI
 - Added Privy authentication (Twitter, Discord, social logins) with embedded wallet via seismic-react ShieldedWalletProvider
 - Bracket UI: 4 regions (East/West/South/Midwest) with visual progression through R64 → R32 → Sweet 16 → Elite 8 → Final Four → Championship
@@ -477,11 +565,13 @@ All notable changes to this project. Every PR must add an entry here.
 - Env vars: VITE_PRIVY_APP_ID, VITE_CHAIN_ID, VITE_RPC_URL
 
 ### 2026-03-14 — Client Library Review Fixes (`packages/client`)
+
 - Replaced hand-written ABI with exact sforge-generated ABI from `contracts/out/MarchMadness.sol/MarchMadness.json` (includes proper `sbytes8` types for shielded inputs)
 - Refactored `MarchMadnessPublicClient` to use `getContract()` + `.read.functionName()` pattern (consistent with `UserClient`'s `getShieldedContract` pattern)
 - Updated ABI test to verify `sbytes8` type on `submitBracket` and `updateBracket` inputs
 
 ### 2026-03-14 — Client Library (`packages/client`)
+
 - Added `src/abi.ts` — MarchMadness contract ABI as const array (uses bytes8 for shielded types, seismic-viem handles shielding)
 - Added `src/client.ts` — three-level client hierarchy:
   - `MarchMadnessPublicClient`: transparent reads (entry count, results, deadline, scores, tags)
@@ -495,15 +585,17 @@ All notable changes to this project. Every PR must add an entry here.
 - 25 total tests passing, typecheck clean
 
 ### 2026-03-14 — Rust HTTP Server (`crates/server`)
+
 - Built `march-madness-server` HTTP server using axum + tokio
 - Endpoints: `GET /api/entries` (full index), `GET /api/entries/:address` (single entry), `GET /api/stats` (total entries + scored count), `GET /health`
 - TTL-cached reads of the indexer's JSON file (5s default) with fs2 shared/read file locks
-- CORS enabled (Access-Control-Allow-Origin: *) for frontend access
+- CORS enabled (Access-Control-Allow-Origin: \*) for frontend access
 - CLI via clap: `--port` (default 3001) and `--index-file` (default `data/entries.json`)
 - Graceful shutdown on SIGINT/SIGTERM
 - Structured logging via tracing
 
 ### 2026-03-14 — CI Workflows + Local CI Script (mise-based)
+
 - Added `mise.toml` (root) — pins sfoundry (nightly), ssolc (2ebb36d), bun (1.3.9) via mise, mirroring samlaf's setup in the seismic repo
 - Added `contracts/mise.toml` — sforge tasks (build, test, fmt-check) with FOUNDRY_SOLC injection
 - Added `packages/mise.toml` — bun tasks (typecheck, lint, build, test) for client and web
@@ -513,11 +605,13 @@ All notable changes to this project. Every PR must add an entry here.
 - Added CLAUDE.md rules #7 (every task ends with PR), #8 (ci.sh ↔ ci.yml sync), #9 (run CI locally before pushing)
 
 ### 2026-03-14 — Smart Contracts
+
 - Added ByteBracket.sol library: ported jimpo's bit-manipulation scoring algorithm to Solidity 0.8 with bytes8 (unchecked blocks for bit ops)
 - Added MarchMadness.sol main contract: shielded bracket storage (sbytes8), submit/update/score/payout lifecycle
 - 57 tests pass with sforge
 
 ### 2026-03-14 — Initial Project Setup
+
 - Created repo structure: contracts/, packages/, crates/, data/, docs/
 - Added CLAUDE.md with project rules and architecture
 - Added README.md with credits to jimpo and pursuingpareto (ByteBracket algorithm author)

--- a/docs/prompts/mauve/1742137200-apply-seismic-brand-colors.txt
+++ b/docs/prompts/mauve/1742137200-apply-seismic-brand-colors.txt
@@ -1,0 +1,84 @@
+Implement the following plan:
+
+# Apply Seismic Brand Colors to March Madness App
+
+## Context
+
+The app currently uses a generic dark theme with indigo accents. We're applying the Seismic brand palette to give it a distinctive, cohesive look.
+
+### Brand Palette
+
+| Name             | Hex       | Character                                  |
+| ---------------- | --------- | ------------------------------------------ |
+| Mauve            | `#825A6D` | Warm mid-tone — primary accent             |
+| Dark Purple      | `#523542` | Rich dark — secondary accent, hover states |
+| Background Black | `#2B2B2B` | Warm dark gray — surfaces                  |
+| Custom White     | `#D1CCBF` | Warm off-white — primary text              |
+| Custom Black     | `#161616` | True dark — deepest background             |
+| Yellow           | `#A6924D` | Muted gold — highlights, gold/warning      |
+
+## Color Mapping
+
+### Theme Variables (`packages/web/src/index.css`)
+
+| Variable                 | Current   | New                                 | Rationale                 |
+| ------------------------ | --------- | ----------------------------------- | ------------------------- |
+| `--color-bg-primary`     | `#0a0a0f` | `#161616` (customBlack)             | Deepest background        |
+| `--color-bg-secondary`   | `#12121a` | `#1e1e1e` (between black & bgBlack) | Slightly lifted           |
+| `--color-bg-tertiary`    | `#1a1a26` | `#2B2B2B` (backgroundBlack)         | Card surfaces             |
+| `--color-bg-hover`       | `#22222e` | `#363636` (lighter warm gray)       | Hover states              |
+| `--color-border`         | `#2a2a3a` | `#3d3d3d` (warm gray)               | Standard borders          |
+| `--color-border-light`   | `#3a3a4a` | `#4a4a4a` (lighter warm gray)       | Light borders             |
+| `--color-text-primary`   | `#e8e8f0` | `#D1CCBF` (customWhite)             | Main text                 |
+| `--color-text-secondary` | `#9898a8` | `#a09a8e` (muted customWhite)       | Secondary text            |
+| `--color-text-muted`     | `#686878` | `#6e6a62` (warm muted)              | Muted text                |
+| `--color-accent`         | `#6366f1` | `#825A6D` (mauve)                   | Primary accent            |
+| `--color-accent-hover`   | `#818cf8` | `#9a7085` (lighter mauve)           | Accent hover              |
+| `--color-success`        | `#22c55e` | `#22c55e`                           | **Keep green** (semantic) |
+| `--color-warning`        | `#f59e0b` | `#A6924D` (yellow)                  | Warnings use brand gold   |
+| `--color-danger`         | `#ef4444` | `#ef4444`                           | **Keep red** (semantic)   |
+| `--color-gold`           | `#fbbf24` | `#A6924D` (yellow)                  | Brand gold                |
+
+> **Design decision**: Success (green) and danger (red) stay as-is — these are semantic/accessibility colors that users universally understand. Changing them would hurt usability.
+
+### Privy Accent Color (`packages/web/src/lib/providers.tsx`)
+
+- Change `accentColor: "#6366f1"` → `"#825A6D"` (mauve)
+
+### Hardcoded Tailwind Colors to Replace
+
+Components use raw Tailwind colors (e.g. `indigo-600`, `amber-400`) instead of the theme variables. These need updating:
+
+| Current                                  | Replace With                                             | Files                             |
+| ---------------------------------------- | -------------------------------------------------------- | --------------------------------- |
+| `indigo-400`, `indigo-600`, `indigo-500` | `accent` / `accent-hover` / `dark-purple` semantic class | GroupsSection, MirrorsSection     |
+| `amber-400`                              | `warning` or `gold`                                      | GroupsSection (entry fee badge)   |
+| `yellow-400`                             | `gold`                                                   | DeadlineCountdown, other warnings |
+
+> Green (`green-400/500`) and red (`red-400/500`) hardcoded colors stay — they're semantic for correct/incorrect picks.
+
+### New Theme Color: Dark Purple
+
+Add `--color-dark-purple: #523542` to the theme for use as a secondary accent (e.g., button hover backgrounds, selected states). This gives us a nice two-tone brand feel.
+
+## Files to Modify
+
+1. **`packages/web/src/index.css`** — Update all `@theme` color variables
+2. **`packages/web/src/lib/providers.tsx`** — Privy accent color
+3. **`packages/web/src/components/GroupsSection.tsx`** — Replace `indigo-*` → accent/dark-purple
+4. **`packages/web/src/components/MirrorsSection.tsx`** — Replace `indigo-*` → accent/dark-purple
+5. **`packages/web/src/components/FinalFour.tsx`** — `gold` already uses CSS var, should auto-update
+6. **`packages/web/src/components/DeadlineCountdown.tsx`** — Replace `yellow-400` if present
+7. **`packages/web/src/components/FaucetBanner.tsx`** — warning colors auto-update via CSS var
+
+## Verification
+
+1. Run `bun run --filter @march-madness/web dev` and visually inspect:
+   - Home page bracket picker
+   - Header / navigation
+   - Groups page (admin badges, buttons)
+   - Leaderboard
+   - FinalFour section
+2. Confirm scrollbar styling picks up new colors
+3. Confirm Privy login modal uses mauve accent
+4. Run `./scripts/ci.sh` to ensure build passes

--- a/packages/web/src/components/BracketRegion.tsx
+++ b/packages/web/src/components/BracketRegion.tsx
@@ -30,7 +30,9 @@ export function BracketRegion({
 
   return (
     <div className="flex flex-col flex-1">
-      <h3 className={`text-sm font-semibold text-accent uppercase tracking-wider mb-3 px-1 ${reversed ? "text-right" : ""}`}>
+      <h3
+        className={`text-sm font-semibold text-accent uppercase tracking-wider mb-3 px-1 ${reversed ? "text-right" : ""}`}
+      >
         {regionName}
       </h3>
       <div className="flex flex-row items-stretch gap-1 flex-1">
@@ -40,7 +42,7 @@ export function BracketRegion({
             : displayIdx;
 
           return (
-            <div key={displayIdx} className="flex flex-col">
+            <div key={displayIdx} className="flex flex-col flex-1">
               <div className="text-[10px] text-text-muted text-center mb-1 whitespace-nowrap">
                 {ROUND_NAMES[actualRoundIdx]}
               </div>
@@ -66,4 +68,3 @@ export function BracketRegion({
     </div>
   );
 }
-

--- a/packages/web/src/components/BracketView.tsx
+++ b/packages/web/src/components/BracketView.tsx
@@ -67,54 +67,50 @@ export function BracketView({
 
   return (
     <div className="overflow-x-auto pb-4">
-      <div className="flex flex-col gap-12 min-w-[1400px]">
+      <div className="grid grid-cols-[1fr_auto_1fr] gap-x-4 gap-y-12 min-w-[1400px] items-stretch">
         {/* Top half: East (left) + Final Four + West (right) */}
-        <div className="flex items-stretch justify-center gap-4">
-          <BracketRegion
-            regionName={regions[0]}
-            rounds={getRegionGames(0)}
-            onPick={onPick}
-            disabled={disabled}
-            tournamentStatus={tournamentStatus}
-          />
-          <FinalFour
-            semifinal1={f4Games[0] ?? null}
-            semifinal2={f4Games[1] ?? null}
-            championship={champGame[0] ?? null}
-            onPick={onPick}
-            disabled={disabled}
-            tournamentStatus={tournamentStatus}
-          />
-          <BracketRegion
-            regionName={regions[1]}
-            rounds={getRegionGames(1)}
-            onPick={onPick}
-            disabled={disabled}
-            reversed
-            tournamentStatus={tournamentStatus}
-          />
-        </div>
+        <BracketRegion
+          regionName={regions[0]}
+          rounds={getRegionGames(0)}
+          onPick={onPick}
+          disabled={disabled}
+          tournamentStatus={tournamentStatus}
+        />
+        <FinalFour
+          semifinal1={f4Games[0] ?? null}
+          semifinal2={f4Games[1] ?? null}
+          championship={champGame[0] ?? null}
+          onPick={onPick}
+          disabled={disabled}
+          tournamentStatus={tournamentStatus}
+        />
+        <BracketRegion
+          regionName={regions[1]}
+          rounds={getRegionGames(1)}
+          onPick={onPick}
+          disabled={disabled}
+          reversed
+          tournamentStatus={tournamentStatus}
+        />
 
         {/* Bottom half: South (left) + spacer + Midwest (right) */}
-        <div className="flex items-stretch justify-center gap-4">
-          <BracketRegion
-            regionName={regions[2]}
-            rounds={getRegionGames(2)}
-            onPick={onPick}
-            disabled={disabled}
-            tournamentStatus={tournamentStatus}
-          />
-          {/* Spacer for alignment with Final Four column */}
-          <div className="min-w-[200px]" />
-          <BracketRegion
-            regionName={regions[3]}
-            rounds={getRegionGames(3)}
-            onPick={onPick}
-            disabled={disabled}
-            reversed
-            tournamentStatus={tournamentStatus}
-          />
-        </div>
+        <BracketRegion
+          regionName={regions[2]}
+          rounds={getRegionGames(2)}
+          onPick={onPick}
+          disabled={disabled}
+          tournamentStatus={tournamentStatus}
+        />
+        {/* Empty cell — grid keeps it aligned with FinalFour column */}
+        <div />
+        <BracketRegion
+          regionName={regions[3]}
+          rounds={getRegionGames(3)}
+          onPick={onPick}
+          disabled={disabled}
+          reversed
+          tournamentStatus={tournamentStatus}
+        />
       </div>
     </div>
   );

--- a/packages/web/src/components/FinalFour.tsx
+++ b/packages/web/src/components/FinalFour.tsx
@@ -21,10 +21,12 @@ export function FinalFour({
   tournamentStatus,
 }: FinalFourProps) {
   return (
-    <div className="flex flex-col items-center gap-6 min-w-[200px]">
-      <h3 className="text-sm font-semibold text-gold uppercase tracking-wider">
+    <div className="flex flex-col items-center min-w-[200px]">
+      <h3 className="text-sm font-semibold text-gold uppercase tracking-wider mb-3 px-1">
         Final Four
       </h3>
+      {/* Spacer matching the round-label row in BracketRegion */}
+      <div className="text-[10px] mb-1 invisible">​</div>
 
       <div className="flex flex-col items-center justify-center gap-8 flex-1">
         {/* Semifinal 1 */}
@@ -49,18 +51,14 @@ export function FinalFour({
               team1={championship.team1}
               team2={championship.team2}
               winner={championship.winner}
-              onPick={(pickTeam1) =>
-                onPick(championship.gameIndex, pickTeam1)
-              }
+              onPick={(pickTeam1) => onPick(championship.gameIndex, pickTeam1)}
               disabled={disabled}
               gameStatus={tournamentStatus?.games[championship.gameIndex]}
             />
           )}
           {championship?.winner && (
             <div className="mt-2 px-4 py-2 bg-gold/20 border border-gold/50 rounded-lg text-center">
-              <div className="text-[10px] text-gold/80 uppercase">
-                Champion
-              </div>
+              <div className="text-[10px] text-gold/80 uppercase">Champion</div>
               <div className="text-lg font-bold text-gold">
                 {championship.winner.seed} {championship.winner.name}
               </div>

--- a/packages/web/src/components/GroupsSection.tsx
+++ b/packages/web/src/components/GroupsSection.tsx
@@ -63,9 +63,9 @@ export function GroupsSection({
   const [joinError, setJoinError] = useState<string | null>(null);
   const [editingGroup, setEditingGroup] = useState<number | null>(null);
   const [editName, setEditName] = useState("");
-  const [resolvedGroupNeedsPassword, setResolvedGroupNeedsPassword] = useState<boolean | null>(
-    initialPassphrase ? true : null,
-  );
+  const [resolvedGroupNeedsPassword, setResolvedGroupNeedsPassword] = useState<
+    boolean | null
+  >(initialPassphrase ? true : null);
   // Track by ID form
   const [trackSlugInput, setTrackSlugInput] = useState("");
   const [trackError, setTrackError] = useState("");
@@ -115,7 +115,12 @@ export function GroupsSection({
 
       // 4. Send the transaction with the correct entry fee
       if (groupData.hasPassword || passphraseInput.trim()) {
-        await groups.joinGroupWithPassword(groupId, passphraseInput.trim(), nameInput.trim(), entryFee);
+        await groups.joinGroupWithPassword(
+          groupId,
+          passphraseInput.trim(),
+          nameInput.trim(),
+          entryFee,
+        );
       } else {
         await groups.joinGroup(groupId, nameInput.trim(), entryFee);
       }
@@ -167,136 +172,155 @@ export function GroupsSection({
       {/* Joined Groups List */}
       {groups.joinedGroups.length > 0 ? (
         <div className="space-y-3 mb-4">
-          {groups.joinedGroups.map(({ groupId, group, members, storedInfo }) => (
-            <div
-              key={groupId}
-              className="rounded-lg bg-bg-tertiary border border-border p-3"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <div>
-                  <span className="font-medium text-text-primary">
-                    {group.displayName}
-                  </span>
-                  <span className="ml-2 text-xs text-text-tertiary">
-                    /{group.slug}
-                  </span>
-                  {storedInfo.admin && (
-                    <span className="ml-2 text-xs text-indigo-400">Admin</span>
-                  )}
-                  {group.entryFee > 0n && (
-                    <span className="ml-2 text-xs text-amber-400">
-                      {formatEther(group.entryFee)} ETH
+          {groups.joinedGroups.map(
+            ({ groupId, group, members, storedInfo }) => (
+              <div
+                key={groupId}
+                className="rounded-lg bg-bg-tertiary border border-border p-3"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <div>
+                    <span className="font-medium text-text-primary">
+                      {group.displayName}
                     </span>
-                  )}
-                </div>
-                <span className="text-xs text-text-secondary">
-                  {group.entryCount} member{group.entryCount !== 1 ? "s" : ""}
-                </span>
-              </div>
-
-              {/* Passphrase + invite link for private groups */}
-              {storedInfo.passphrase && (
-                <div className="space-y-1 mb-2">
-                  <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
-                    <span className="text-text-tertiary mr-1">Passphrase:</span>
-                    <span className="text-text-primary">{storedInfo.passphrase}</span>
-                    <CopyButton text={storedInfo.passphrase} />
-                  </div>
-                  <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
-                    <span className="text-text-tertiary mr-1">Invite link:</span>
-                    <span className="text-text-primary truncate">
-                      {`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
+                    <span className="ml-2 text-xs text-text-tertiary">
+                      /{group.slug}
                     </span>
-                    <CopyButton
-                      text={`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* Member list (compact) */}
-              <div className="text-xs text-text-secondary space-y-0.5 mb-2">
-                {members.slice(0, 5).map((m, i) => (
-                  <div key={i} className="flex justify-between">
-                    <span>{m.name || m.addr.slice(0, 10) + "..."}</span>
-                    {m.isScored && (
-                      <span className="text-text-tertiary">Score: {m.score}</span>
+                    {storedInfo.admin && (
+                      <span className="ml-2 text-xs text-accent">Admin</span>
+                    )}
+                    {group.entryFee > 0n && (
+                      <span className="ml-2 text-xs text-gold">
+                        {formatEther(group.entryFee)} ETH
+                      </span>
                     )}
                   </div>
-                ))}
-                {members.length > 5 && (
-                  <div className="text-text-tertiary">
-                    +{members.length - 5} more
+                  <span className="text-xs text-text-secondary">
+                    {group.entryCount} member{group.entryCount !== 1 ? "s" : ""}
+                  </span>
+                </div>
+
+                {/* Passphrase + invite link for private groups */}
+                {storedInfo.passphrase && (
+                  <div className="space-y-1 mb-2">
+                    <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
+                      <span className="text-text-tertiary mr-1">
+                        Passphrase:
+                      </span>
+                      <span className="text-text-primary">
+                        {storedInfo.passphrase}
+                      </span>
+                      <CopyButton text={storedInfo.passphrase} />
+                    </div>
+                    <div className="flex items-center text-xs text-text-secondary bg-bg-primary rounded px-2 py-1">
+                      <span className="text-text-tertiary mr-1">
+                        Invite link:
+                      </span>
+                      <span className="text-text-primary truncate">
+                        {`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
+                      </span>
+                      <CopyButton
+                        text={`${window.location.origin}/groups?slug=${encodeURIComponent(group.slug)}&password=${encodeURIComponent(storedInfo.passphrase)}`}
+                      />
+                    </div>
                   </div>
                 )}
-              </div>
 
-              {/* Actions */}
-              <div className="flex gap-2 mt-2">
-                {isBeforeDeadline && (
-                  <>
-                    {editingGroup === groupId ? (
-                      <div className="flex gap-1 flex-1">
-                        <input
-                          type="text"
-                          value={editName}
-                          onChange={(e) => setEditName(e.target.value)}
-                          placeholder="New display name"
-                          className="flex-1 px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-primary"
-                        />
-                        <button
-                          onClick={() => handleEditName(groupId)}
-                          disabled={groups.isLoading}
-                          className="px-2 py-1 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-500 disabled:opacity-50"
-                        >
-                          Save
-                        </button>
-                        <button
-                          onClick={() => setEditingGroup(null)}
-                          className="px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-secondary hover:text-text-primary"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    ) : (
-                      <>
-                        <button
-                          onClick={() => {
-                            setEditingGroup(groupId);
-                            setEditName("");
-                          }}
-                          className="px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-secondary hover:text-text-primary"
-                        >
-                          Edit Name
-                        </button>
-                        <button
-                          onClick={() => groups.leaveGroup(groupId)}
-                          disabled={groups.isLoading}
-                          className="px-2 py-1 text-xs rounded bg-red-900/30 border border-red-800 text-red-400 hover:bg-red-900/50 disabled:opacity-50"
-                        >
-                          Leave
-                        </button>
-                      </>
-                    )}
-                  </>
-                )}
+                {/* Member list (compact) */}
+                <div className="text-xs text-text-secondary space-y-0.5 mb-2">
+                  {members.slice(0, 5).map((m, i) => (
+                    <div key={i} className="flex justify-between">
+                      <span>{m.name || m.addr.slice(0, 10) + "..."}</span>
+                      {m.isScored && (
+                        <span className="text-text-tertiary">
+                          Score: {m.score}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                  {members.length > 5 && (
+                    <div className="text-text-tertiary">
+                      +{members.length - 5} more
+                    </div>
+                  )}
+                </div>
+
+                {/* Actions */}
+                <div className="flex gap-2 mt-2">
+                  {isBeforeDeadline && (
+                    <>
+                      {editingGroup === groupId ? (
+                        <div className="flex gap-1 flex-1">
+                          <input
+                            type="text"
+                            value={editName}
+                            onChange={(e) => setEditName(e.target.value)}
+                            placeholder="New display name"
+                            className="flex-1 px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-primary"
+                          />
+                          <button
+                            onClick={() => handleEditName(groupId)}
+                            disabled={groups.isLoading}
+                            className="px-2 py-1 text-xs rounded bg-accent text-white hover:bg-accent-hover disabled:opacity-50"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingGroup(null)}
+                            className="px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-secondary hover:text-text-primary"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => {
+                              setEditingGroup(groupId);
+                              setEditName("");
+                            }}
+                            className="px-2 py-1 text-xs rounded bg-bg-primary border border-border text-text-secondary hover:text-text-primary"
+                          >
+                            Edit Name
+                          </button>
+                          <button
+                            onClick={() => groups.leaveGroup(groupId)}
+                            disabled={groups.isLoading}
+                            className="px-2 py-1 text-xs rounded bg-red-900/30 border border-red-800 text-red-400 hover:bg-red-900/50 disabled:opacity-50"
+                          >
+                            Leave
+                          </button>
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            ),
+          )}
         </div>
       ) : (
         <p className="text-sm text-text-muted mb-4">
           No groups joined yet. Join one below, or create a new group from the{" "}
-          <a href="/groups" className="text-accent hover:underline">Groups</a> page.
+          <a href="/groups" className="text-accent hover:underline">
+            Groups
+          </a>{" "}
+          page.
         </p>
       )}
 
       {/* Join Group Form */}
       {walletConnected && isBeforeDeadline && (
         <div className="space-y-3">
-          <h3 className="text-sm font-medium text-text-secondary">Join a Group</h3>
+          <h3 className="text-sm font-medium text-text-secondary">
+            Join a Group
+          </h3>
           <div className="space-y-2">
-            <SlugInput value={slugInput} onChange={setSlugInput} placeholder="Group slug" />
+            <SlugInput
+              value={slugInput}
+              onChange={setSlugInput}
+              placeholder="Group slug"
+            />
             <input
               type="text"
               value={nameInput}
@@ -308,32 +332,43 @@ export function GroupsSection({
               type="text"
               value={passphraseInput}
               onChange={(e) => setPassphraseInput(e.target.value)}
-              placeholder={resolvedGroupNeedsPassword ? "Passphrase (required)" : "Passphrase (leave blank for public groups)"}
+              placeholder={
+                resolvedGroupNeedsPassword
+                  ? "Passphrase (required)"
+                  : "Passphrase (leave blank for public groups)"
+              }
               className={`w-full max-w-md px-3 py-1.5 text-sm rounded-lg bg-bg-primary border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors ${
-                resolvedGroupNeedsPassword ? "border-amber-500/50" : "border-border"
+                resolvedGroupNeedsPassword
+                  ? "border-warning/50"
+                  : "border-border"
               }`}
             />
             <div>
               <button
                 onClick={handleJoin}
-                disabled={groups.isLoading || !slugInput.trim() || !nameInput.trim()}
+                disabled={
+                  groups.isLoading || !slugInput.trim() || !nameInput.trim()
+                }
                 className="px-4 py-1.5 text-sm rounded-lg bg-accent text-white hover:bg-accent-hover disabled:opacity-50 transition-colors font-medium"
               >
                 {groups.isLoading ? "Joining..." : "Join"}
               </button>
             </div>
           </div>
-          {joinError && (
-            <p className="text-xs text-red-400">{joinError}</p>
-          )}
+          {joinError && <p className="text-xs text-red-400">{joinError}</p>}
 
           {/* Track by slug (separate, small) */}
           <div className="pt-2 border-t border-border">
-            <h4 className="text-xs text-text-tertiary mb-1">Already a member? Track by slug</h4>
+            <h4 className="text-xs text-text-tertiary mb-1">
+              Already a member? Track by slug
+            </h4>
             <div className="flex gap-2 max-w-md">
               <SlugInput
                 value={trackSlugInput}
-                onChange={(v) => { setTrackSlugInput(v); setTrackError(""); }}
+                onChange={(v) => {
+                  setTrackSlugInput(v);
+                  setTrackError("");
+                }}
               />
               <button
                 onClick={handleTrackBySlug}
@@ -343,7 +378,9 @@ export function GroupsSection({
                 Track
               </button>
             </div>
-            {trackError && <p className="text-xs text-red-400 mt-1">{trackError}</p>}
+            {trackError && (
+              <p className="text-xs text-red-400 mt-1">{trackError}</p>
+            )}
           </div>
         </div>
       )}

--- a/packages/web/src/components/MirrorsSection.tsx
+++ b/packages/web/src/components/MirrorsSection.tsx
@@ -60,7 +60,9 @@ export function MirrorsSection() {
         mirrorIds.map(async (mirrorId) => {
           try {
             const mirror = await mirrorPublic.getMirror(BigInt(mirrorId));
-            const entryCount = await mirrorPublic.getEntryCount(BigInt(mirrorId));
+            const entryCount = await mirrorPublic.getEntryCount(
+              BigInt(mirrorId),
+            );
             return { mirrorId, mirror, entryCount: Number(entryCount) };
           } catch {
             return null;
@@ -120,7 +122,9 @@ export function MirrorsSection() {
         setMirrorIds(updated);
         setTrackInput("");
       } catch (err) {
-        setTrackError(err instanceof Error ? err.message : "Failed to track mirror");
+        setTrackError(
+          err instanceof Error ? err.message : "Failed to track mirror",
+        );
       } finally {
         setIsTracking(false);
       }
@@ -153,8 +157,12 @@ export function MirrorsSection() {
               className="flex items-center justify-between rounded-lg bg-bg-tertiary border border-border/50 px-3 py-2"
             >
               <div>
-                <span className="text-sm text-text-primary">{mirror.displayName}</span>
-                <span className="ml-2 text-xs text-text-tertiary">/{mirror.slug}</span>
+                <span className="text-sm text-text-primary">
+                  {mirror.displayName}
+                </span>
+                <span className="ml-2 text-xs text-text-tertiary">
+                  /{mirror.slug}
+                </span>
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-xs text-text-secondary">
@@ -195,14 +203,12 @@ export function MirrorsSection() {
         <button
           onClick={() => trackMirror(trackInput)}
           disabled={isTracking || !trackInput.trim()}
-          className="px-3 py-1.5 text-sm rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+          className="px-3 py-1.5 text-sm rounded-lg bg-accent text-white hover:bg-accent-hover disabled:opacity-50 transition-colors"
         >
           {isTracking ? "..." : "Track"}
         </button>
       </div>
-      {trackError && (
-        <p className="mt-1 text-xs text-red-400">{trackError}</p>
-      )}
+      {trackError && <p className="mt-1 text-xs text-red-400">{trackError}</p>}
     </div>
   );
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1,21 +1,22 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg-primary: #0a0a0f;
-  --color-bg-secondary: #12121a;
-  --color-bg-tertiary: #1a1a26;
-  --color-bg-hover: #22222e;
-  --color-border: #2a2a3a;
-  --color-border-light: #3a3a4a;
-  --color-text-primary: #e8e8f0;
-  --color-text-secondary: #9898a8;
-  --color-text-muted: #686878;
-  --color-accent: #6366f1;
-  --color-accent-hover: #818cf8;
+  --color-bg-primary: #161616;
+  --color-bg-secondary: #1e1e1e;
+  --color-bg-tertiary: #2b2b2b;
+  --color-bg-hover: #363636;
+  --color-border: #3d3d3d;
+  --color-border-light: #4a4a4a;
+  --color-text-primary: #d1ccbf;
+  --color-text-secondary: #a09a8e;
+  --color-text-muted: #6e6a62;
+  --color-accent: #825a6d;
+  --color-accent-hover: #9a7085;
+  --color-dark-purple: #523542;
   --color-success: #22c55e;
-  --color-warning: #f59e0b;
+  --color-warning: #a6924d;
   --color-danger: #ef4444;
-  --color-gold: #fbbf24;
+  --color-gold: #a6924d;
 }
 
 body {

--- a/packages/web/src/lib/providers.tsx
+++ b/packages/web/src/lib/providers.tsx
@@ -42,7 +42,7 @@ export const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
         },
         appearance: {
           theme: "dark",
-          accentColor: "#6366f1",
+          accentColor: "#825A6D",
         },
       }}
     >

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -74,7 +74,9 @@ export function HomePage() {
     if (firstNibble < 8) {
       const fixedNibble = (firstNibble | 0x8).toString(16);
       const fixed = `0x${fixedNibble}${cleaned.slice(3)}` as `0x${string}`;
-      setHexError(`Pasted ${cleaned} — missing sentinel bit. Loaded ${fixed} (same picks, valid for submission).`);
+      setHexError(
+        `Pasted ${cleaned} — missing sentinel bit. Loaded ${fixed} (same picks, valid for submission).`,
+      );
       bracket.loadFromHex(fixed);
     } else {
       setHexError(null);
@@ -108,9 +110,7 @@ export function HomePage() {
 
   return (
     <>
-      {showFaucetBanner && (
-        <FaucetBanner address={contract.walletAddress!} />
-      )}
+      {showFaucetBanner && <FaucetBanner address={contract.walletAddress!} />}
 
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
         <DeadlineCountdown />
@@ -129,7 +129,7 @@ export function HomePage() {
               title="Reset Picks?"
               description={
                 contract.hasSubmitted
-                  ? "This will clear all 63 picks. You can re-load your on-chain submission by clicking \"Load bracket\"."
+                  ? 'This will clear all 63 picks. You can re-load your on-chain submission by clicking "Load bracket".'
                   : "This will clear all 63 picks. This can't be undone."
               }
               confirmLabel="Reset"
@@ -177,7 +177,12 @@ export function HomePage() {
                       title="Copy hex"
                       className="p-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors"
                     >
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
                         <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z" />
                         <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.439A1.5 1.5 0 0 0 8.378 6H4.5Z" />
                       </svg>
@@ -187,12 +192,18 @@ export function HomePage() {
                     onClick={() => {
                       setHexExpanded(false);
                       setHexOpen(true);
-                      if (collapseTimer.current) clearTimeout(collapseTimer.current);
+                      if (collapseTimer.current)
+                        clearTimeout(collapseTimer.current);
                     }}
                     title="Edit hex"
                     className="p-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors"
                   >
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      className="w-3.5 h-3.5"
+                    >
                       <path d="m5.433 13.917 1.262-3.155A4 4 0 0 1 7.58 9.42l6.92-6.918a2.121 2.121 0 0 1 3 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 0 1-.65-.65Z" />
                       <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0 0 10 3H4.75A2.75 2.75 0 0 0 2 5.75v9.5A2.75 2.75 0 0 0 4.75 18h9.5A2.75 2.75 0 0 0 17 15.25V10a.75.75 0 0 0-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5Z" />
                     </svg>
@@ -205,7 +216,7 @@ export function HomePage() {
       </div>
 
       {hexError && (
-        <div className="mb-2 px-3 py-1.5 text-xs text-yellow-400 bg-yellow-400/10 border border-yellow-400/30 rounded-lg">
+        <div className="mb-2 px-3 py-1.5 text-xs text-warning bg-warning/10 border border-warning/30 rounded-lg">
           {hexError}
         </div>
       )}
@@ -224,7 +235,9 @@ export function HomePage() {
         getGamesForRound={bracket.getGamesForRound}
         onPick={bracket.makePick}
         disabled={isLocked}
-        tournamentStatus={isLocked && tournamentStatus ? tournamentStatus : undefined}
+        tournamentStatus={
+          isLocked && tournamentStatus ? tournamentStatus : undefined
+        }
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Replace generic indigo/dark-blue theme with Seismic brand palette: mauve (`#825A6D`) primary accent, dark purple (`#523542`) secondary, warm grays for backgrounds/borders, muted gold (`#A6924D`) for warnings/highlights
- Update all `@theme` CSS variables, Privy accent color, and replace hardcoded `indigo-*`/`amber-*`/`yellow-*` Tailwind classes with semantic theme tokens
- Fix Final Four not vertically centered — title spacing now matches BracketRegion structure
- Fix right-side regions (West/Midwest) having dead space on the right — switched outer layout to CSS grid (`grid-cols-[1fr_auto_1fr]`) and made round columns `flex-1`

## Files changed
- `packages/web/src/index.css` — Theme variables
- `packages/web/src/lib/providers.tsx` — Privy accent
- `packages/web/src/components/GroupsSection.tsx` — Semantic color classes
- `packages/web/src/components/MirrorsSection.tsx` — Semantic color classes
- `packages/web/src/pages/HomePage.tsx` — Warning color classes
- `packages/web/src/components/BracketView.tsx` — Grid layout for column alignment
- `packages/web/src/components/BracketRegion.tsx` — flex-1 round columns
- `packages/web/src/components/FinalFour.tsx` — Vertical centering fix

## Test plan
- [ ] Visual inspection: home page, bracket picker, groups page, leaderboard
- [ ] Confirm scrollbar picks up new colors
- [ ] Confirm Privy login modal uses mauve accent
- [ ] Verify bracket regions align between top and bottom halves
- [ ] CI passes (typecheck, lint, build, test)