### PR TITLE
Fix group slug length validation (#115)

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -15,6 +15,11 @@ All notable changes to this project. Every PR must add an entry here.
 ### 2026-03-16 — Fix scoreboard null data for future dates
 - **ncaa-api**: Treat missing `data`/`scoreboard` in NCAA API response as empty list instead of error. The API returns null for dates without game data (e.g. future dates), which is not an error condition.
 
+### 2026-03-16 — Fix group slug length validation (#115)
+
+- **UI**: Changed `slugify()` truncation from 40 to 32 characters to match `BracketGroups.sol` `MAX_SLUG_LENGTH`.
+- **UI**: Added client-side validation message when slug is truncated to the contract limit, preventing confusing on-chain `SlugTooLong()` reverts.
+
 ### 2026-03-16 — Apply Seismic brand colors
 
 - **UI**: Replaced generic indigo/dark-blue theme with Seismic brand palette (mauve `#825A6D`, dark purple `#523542`, warm grays, muted gold `#A6924D`).

--- a/docs/prompts/cdai__fix-slug-length-115/1742140800-fix-slug-length.txt
+++ b/docs/prompts/cdai__fix-slug-length-115/1742140800-fix-slug-length.txt
@@ -1,0 +1,1 @@
+do all of those 4, for each do your work in worktrees off of main branch

--- a/packages/web/src/pages/GroupsPage.tsx
+++ b/packages/web/src/pages/GroupsPage.tsx
@@ -6,12 +6,14 @@ import { GroupsSection } from "../components/GroupsSection";
 import { useContract } from "../hooks/useContract";
 import { useGroups } from "../hooks/useGroups";
 
+const MAX_SLUG_LENGTH = 32; // Must match BracketGroups.sol MAX_SLUG_LENGTH
+
 function slugify(text: string): string {
   return text
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
+    .slice(0, MAX_SLUG_LENGTH);
 }
 
 export function GroupsPage() {
@@ -44,6 +46,8 @@ export function GroupsPage() {
     setSlugManual(true);
     setSlug(slugify(value));
   };
+
+  const slugAtLimit = slug.length >= MAX_SLUG_LENGTH;
 
   const handleCreate = async () => {
     if (!displayName.trim() || !slug.trim()) return;
@@ -113,6 +117,11 @@ export function GroupsPage() {
                     className="w-full px-3 py-2 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors font-mono"
                   />
                 </div>
+                {slugAtLimit && (
+                  <p className="text-xs text-yellow-400 mt-1">
+                    Slug truncated to {MAX_SLUG_LENGTH} characters (contract limit).
+                  </p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Aligned frontend `slugify()` truncation from 40 to 32 characters to match `BracketGroups.sol` `MAX_SLUG_LENGTH`
- Added client-side validation message when the slug hits the 32-character limit, preventing users from hitting an on-chain `SlugTooLong()` revert

## Test plan

- [ ] Type a group display name longer than 32 characters and verify the auto-generated slug is truncated at 32
- [ ] Manually edit the slug field with >32 characters and verify truncation + warning message appears
- [ ] Verify group creation succeeds with a 32-character slug
- [ ] Verify no regression for short slugs (no warning shown)

Closes #115