### PR TITLE
Fix public group joins failing with non-empty passphrase

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,12 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Fix public group joins failing when passphrase field is non-empty
+
+- **UI**: Replaced the always-visible passphrase input with a "Private group" toggle checkbox. Passphrase field only appears when the toggle is on, and `handleJoin()` uses the toggle state (not input text or API-resolved group type) to choose between `joinGroup` and `joinGroupWithPassword`. This eliminates the bug where leftover passphrase text caused public group joins to revert with `GroupIsNotPasswordProtected`.
+- **UI**: Removed `resolvedGroupNeedsPassword` state and associated pre-check logic. The user explicitly controls whether to use the password path.
+- **UI**: Invite links with `?password=...` query params still work — the toggle defaults to ON when `initialPassphrase` is provided.
+
 ### 2026-03-17 — Reorganize Groups page with public groups browse and search
 
 - **UI**: Reorganized Groups page into four clear sections: Public Groups, Your Groups, Join Private Group, Create Group.

--- a/docs/prompts/cdai__fix-public-group-join-117/1742140800-fix-public-group-join.txt
+++ b/docs/prompts/cdai__fix-public-group-join-117/1742140800-fix-public-group-join.txt
@@ -1,0 +1,1 @@
+Fix public group joins failing when passphrase field has text (#117)

--- a/packages/web/src/components/PrivateJoinForm.tsx
+++ b/packages/web/src/components/PrivateJoinForm.tsx
@@ -21,6 +21,7 @@ export function PrivateJoinForm({
 }: PrivateJoinFormProps) {
   const [slugInput, setSlugInput] = useState(initialSlug);
   const [nameInput, setNameInput] = useState("");
+  const [isPrivateJoin, setIsPrivateJoin] = useState(!!initialPassphrase);
   const [passphraseInput, setPassphraseInput] = useState(initialPassphrase);
   const [joinError, setJoinError] = useState<string | null>(null);
 
@@ -37,11 +38,6 @@ export function PrivateJoinForm({
 
       const [groupId, groupData] = result;
 
-      if (groupData.hasPassword && !passphraseInput.trim()) {
-        setJoinError("This is a private group — enter the passphrase to join");
-        return;
-      }
-
       const entryFee = groupData.entryFee;
       if (entryFee > 0n) {
         if (walletBalance === null) {
@@ -56,7 +52,9 @@ export function PrivateJoinForm({
         }
       }
 
-      if (groupData.hasPassword || passphraseInput.trim()) {
+      // Use the toggle state (not field contents or API-resolved group type)
+      // to choose between joinGroup and joinGroupWithPassword
+      if (isPrivateJoin) {
         await groups.joinGroupWithPassword(
           groupId,
           passphraseInput.trim(),
@@ -70,6 +68,7 @@ export function PrivateJoinForm({
       setSlugInput("");
       setNameInput("");
       setPassphraseInput("");
+      setIsPrivateJoin(false);
     } catch (err) {
       setJoinError(err instanceof Error ? err.message : "Failed to join");
     }
@@ -102,13 +101,24 @@ export function PrivateJoinForm({
           placeholder="Your display name"
           className="w-full px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
         />
-        <input
-          type="text"
-          value={passphraseInput}
-          onChange={(e) => setPassphraseInput(e.target.value)}
-          placeholder="Passphrase"
-          className="w-full px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
-        />
+        <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPrivateJoin}
+            onChange={(e) => setIsPrivateJoin(e.target.checked)}
+            className="accent-accent"
+          />
+          Private group
+        </label>
+        {isPrivateJoin && (
+          <input
+            type="text"
+            value={passphraseInput}
+            onChange={(e) => setPassphraseInput(e.target.value)}
+            placeholder="Passphrase"
+            className="w-full px-3 py-1.5 text-sm rounded-lg bg-bg-primary border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50 transition-colors"
+          />
+        )}
         <div>
           <button
             onClick={handleJoin}


### PR DESCRIPTION
## Summary

Closes #117

- Replaced the always-visible passphrase input field with a "Private group" toggle checkbox. The passphrase field only appears when the toggle is checked.
- `handleJoin()` now uses the toggle state (`isPrivateJoin`) to choose between `joinGroup` and `joinGroupWithPassword`, instead of checking input text or the API-resolved group type.
- Removed the `resolvedGroupNeedsPassword` state and its associated pre-check logic.
- Invite links with `?password=...` still work: the toggle defaults to ON when `initialPassphrase` is provided.

**Root cause:** The old condition `groupData.hasPassword || passphraseInput.trim()` routed public group joins through the password-protected contract method whenever leftover text existed in the passphrase field, causing a `GroupIsNotPasswordProtected` revert.

## Test plan

- [ ] Join a public group with no text in passphrase area (toggle off) -- should succeed
- [ ] Join a public group with "Private group" toggle off -- should call `joinGroup`, not `joinGroupWithPassword`
- [ ] Join a private group with toggle on + correct passphrase -- should succeed
- [ ] Open an invite link with `?slug=x&password=y` -- toggle should default to ON with passphrase pre-filled
- [ ] Verify passphrase input is hidden when toggle is off