### PR TITLE
Calibrator: 100k default sims, demote --cache-ttl to passthrough arg

### DIFF
--- a/crates/bracket-sim/src/bin/calibrate.rs
+++ b/crates/bracket-sim/src/bin/calibrate.rs
@@ -37,7 +37,7 @@ struct CalibrateArgs {
     output: Option<PathBuf>,
 
     /// Simulations per calibration iteration
-    #[arg(short = 'n', long, default_value_t = 10000, value_parser = parse_nonzero_usize)]
+    #[arg(short = 'n', long, default_value_t = 100_000, value_parser = parse_nonzero_usize)]
     sims_per_iter: usize,
 
     /// Maximum calibration iterations

--- a/scripts/refresh-ratings.sh
+++ b/scripts/refresh-ratings.sh
@@ -4,28 +4,22 @@ set -euo pipefail
 # Scrape fresh KenPom ratings and then run Kalshi calibration to update goose values.
 #
 # Usage:
-#   ./scripts/refresh-ratings.sh                       # scrape + calibrate (2h cache TTL)
-#   ./scripts/refresh-ratings.sh --cache-ttl 3600      # custom Kalshi cache TTL (seconds)
+#   ./scripts/refresh-ratings.sh                       # scrape + calibrate
 #   ./scripts/refresh-ratings.sh --no-kalshi           # scrape kenpom only, skip calibration
 #   ./scripts/refresh-ratings.sh --no-kenpom           # calibrate only, skip kenpom scrape
-#   ./scripts/refresh-ratings.sh -- --max-iter 200     # pass extra flags to calibrator
+#   ./scripts/refresh-ratings.sh -- --cache-ttl 3600   # pass extra flags to calibrator
 #
 # Everything after "--" is forwarded to the calibrate binary.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-CACHE_TTL="7200"  # 2 hours
 RUN_KENPOM=true
 RUN_KALSHI=true
 CALIBRATE_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --cache-ttl)
-      CACHE_TTL="$2"
-      shift 2
-      ;;
     --no-kalshi)
       RUN_KALSHI=false
       shift
@@ -41,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo "Unknown option: $1" >&2
-      echo "Usage: $0 [--cache-ttl SECONDS] [--no-kalshi] [--no-kenpom] [-- CALIBRATE_ARGS...]" >&2
+      echo "Usage: $0 [--no-kalshi] [--no-kenpom] [-- CALIBRATE_ARGS...]" >&2
       exit 1
       ;;
   esac
@@ -61,9 +55,8 @@ fi
 
 # ── Step 2/2: Kalshi calibration ────────────────────────────
 if [[ "$RUN_KALSHI" == true ]]; then
-  echo "[2/2] Running Kalshi calibration (cache-ttl=${CACHE_TTL}s)..."
+  echo "[2/2] Running Kalshi calibration..."
   cargo run --release -p bracket-sim --bin calibrate -- \
-    --cache-ttl "$CACHE_TTL" \
     "${CALIBRATE_ARGS[@]+"${CALIBRATE_ARGS[@]}"}"
   echo "      Calibrated ratings saved to data/2026/men/kenpom.csv"
 else


### PR DESCRIPTION
## Summary
- Increase `sims_per_iter` default from 10,000 → 100,000 for better convergence out of the box
- `refresh-ratings.sh`: remove `--cache-ttl` as a top-level script arg — it's now only passable after `--` (forwarded to the calibrate binary), keeping the script interface simpler

## Test plan
- [ ] `cargo build -p bracket-sim --bin calibrate` compiles
- [ ] `calibrate --help` shows `100000` as the default for `--sims-per-iter`
- [ ] `./scripts/refresh-ratings.sh -- --cache-ttl 3600` works
- [ ] `./scripts/refresh-ratings.sh --cache-ttl 3600` errors with "Unknown option"