### PR TITLE
Add denormalized entry count counters in Redis

### DIFF
--- a/crates/indexer/src/commands/backfill.rs
+++ b/crates/indexer/src/commands/backfill.rs
@@ -51,8 +51,11 @@ pub async fn run(
                 }
             };
             let addr_str = format!("{address:#x}");
-            redis_store::upsert_bracket_submitted(redis, &addr_str, block_num, ts).await?;
-            entry_count += 1;
+            let is_new =
+                redis_store::upsert_bracket_submitted(redis, &addr_str, block_num, ts).await?;
+            if is_new {
+                entry_count += 1;
+            }
         }
 
         if !logs.is_empty() {
@@ -209,17 +212,44 @@ pub async fn run(
 
     info!(entries = entry_count, "backfill complete");
 
-    // Sanity check (MarchMadness only).
-    info!("running sanity check");
+    // ── Sanity checks ─────────────────────────────────────────────────
+
+    // Total entry count: verify counter key matches HLEN and on-chain.
+    info!("running sanity checks");
     let on_chain_count = p.get_entry_count(mm_addr).await?;
-    let redis_count = redis_store::get_entry_count(redis).await? as u32;
-    if on_chain_count == redis_count {
-        info!(count = redis_count, "sanity check passed");
+    let redis_hlen = redis_store::get_entry_count(redis).await? as u32;
+    let counter_val = redis_store::get_stored_entry_count(redis).await? as u32;
+
+    if counter_val == redis_hlen && redis_hlen == on_chain_count {
+        info!(count = redis_hlen, "entry count sanity check passed");
     } else {
         info!(
-            local = redis_count,
+            counter = counter_val,
+            hlen = redis_hlen,
             on_chain = on_chain_count,
             "WARNING: entry count mismatch"
+        );
+    }
+
+    // Group member counts: verify member_count matches members.len().
+    let groups = redis_store::get_all_groups(redis).await?;
+    let mut groups_ok = true;
+    for (id, data) in &groups {
+        if data.member_count != data.members.len() as u32 {
+            info!(
+                group_id = %id,
+                slug = %data.slug,
+                stored_count = data.member_count,
+                actual_count = data.members.len(),
+                "WARNING: group member count mismatch"
+            );
+            groups_ok = false;
+        }
+    }
+    if groups_ok {
+        info!(
+            groups = groups.len(),
+            "group member count sanity checks passed"
         );
     }
 

--- a/crates/indexer/src/commands/check.rs
+++ b/crates/indexer/src/commands/check.rs
@@ -1,10 +1,10 @@
-//! Sanity check: compare Redis entry count with on-chain getEntryCount().
+//! Sanity check: compare Redis counts with on-chain contract state.
 
 use crate::provider::IndexerProvider;
-use crate::redis_store;
 use alloy_primitives::Address;
 use eyre::{Result, WrapErr};
 use redis::aio::MultiplexedConnection;
+use seismic_march_madness::redis_keys::{KEY_ENTRIES, KEY_ENTRY_COUNT};
 use tracing::info;
 
 pub async fn run(
@@ -14,15 +14,30 @@ pub async fn run(
 ) -> Result<()> {
     let contract_addr: Address = contract.parse().wrap_err("invalid contract address")?;
 
+    // Read counter and HLEN atomically via pipeline.
+    let (counter, hlen): (Option<u64>, u64) = redis::pipe()
+        .get(KEY_ENTRY_COUNT)
+        .hlen(KEY_ENTRIES)
+        .query_async(redis)
+        .await
+        .wrap_err("failed to read Redis counts")?;
+
+    let counter = counter.unwrap_or(0);
     let on_chain = p.get_entry_count(contract_addr).await?;
-    let local = redis_store::get_entry_count(redis).await? as u32;
 
-    info!(local, on_chain, "entry counts");
+    info!(counter, hlen, on_chain, "entry counts");
 
-    if local == on_chain {
-        info!("OK — counts match");
-    } else {
-        info!(local, on_chain, "MISMATCH — consider running backfill");
+    let mut ok = true;
+    if counter != hlen {
+        info!(counter, hlen, "MISMATCH: counter key != HLEN");
+        ok = false;
+    }
+    if hlen != on_chain as u64 {
+        info!(hlen, on_chain, "MISMATCH: HLEN != on-chain");
+        ok = false;
+    }
+    if ok {
+        info!("OK — all entry counts match");
     }
 
     Ok(())

--- a/crates/indexer/src/commands/check_redis.rs
+++ b/crates/indexer/src/commands/check_redis.rs
@@ -1,0 +1,108 @@
+//! Redis-internal consistency check for stored counts.
+//!
+//! Verifies that denormalized counters match the actual data in Redis.
+//! Does NOT require RPC access — purely local checks.
+//!
+//! Modes:
+//! - `--total` (default): counter key vs HLEN of entries hash
+//! - `--group <slug>`: specific group's member_count vs members.len()
+//! - `--all-groups`: all groups
+
+use crate::redis_store;
+use eyre::{Result, WrapErr};
+use redis::aio::MultiplexedConnection;
+use seismic_march_madness::redis_keys::{KEY_ENTRIES, KEY_ENTRY_COUNT};
+use tracing::info;
+
+/// What to check.
+pub enum CheckMode {
+    Total,
+    Group(String),
+    AllGroups,
+}
+
+pub async fn run(redis: &mut MultiplexedConnection, mode: CheckMode) -> Result<()> {
+    match mode {
+        CheckMode::Total => check_total(redis).await,
+        CheckMode::Group(slug) => check_group(redis, &slug).await,
+        CheckMode::AllGroups => check_all_groups(redis).await,
+    }
+}
+
+async fn check_total(redis: &mut MultiplexedConnection) -> Result<()> {
+    // Read counter and HLEN atomically via pipeline.
+    let (counter, hlen): (Option<u64>, u64) = redis::pipe()
+        .get(KEY_ENTRY_COUNT)
+        .hlen(KEY_ENTRIES)
+        .query_async(redis)
+        .await
+        .wrap_err("failed to read Redis counts")?;
+
+    let counter = counter.unwrap_or(0);
+
+    info!(counter, hlen, "entry counts");
+
+    if counter == hlen {
+        info!("OK — counter matches HLEN");
+    } else {
+        info!(counter, hlen, "MISMATCH: counter key != HLEN");
+    }
+
+    Ok(())
+}
+
+async fn check_group(redis: &mut MultiplexedConnection, slug: &str) -> Result<()> {
+    let Some((id, data)) = redis_store::get_group_by_slug(redis, slug).await? else {
+        info!(slug, "group not found");
+        return Ok(());
+    };
+
+    let actual = data.members.len() as u32;
+    info!(
+        group_id = %id,
+        slug = %data.slug,
+        stored_count = data.member_count,
+        actual_count = actual,
+        "group member counts"
+    );
+
+    if data.member_count == actual {
+        info!("OK — group member count matches");
+    } else {
+        info!("MISMATCH: stored member_count != members.len()");
+    }
+
+    Ok(())
+}
+
+async fn check_all_groups(redis: &mut MultiplexedConnection) -> Result<()> {
+    let groups = redis_store::get_all_groups(redis).await?;
+
+    if groups.is_empty() {
+        info!("no groups found");
+        return Ok(());
+    }
+
+    let mut mismatches = 0u32;
+    for (id, data) in &groups {
+        let actual = data.members.len() as u32;
+        if data.member_count != actual {
+            info!(
+                group_id = %id,
+                slug = %data.slug,
+                stored_count = data.member_count,
+                actual_count = actual,
+                "MISMATCH"
+            );
+            mismatches += 1;
+        }
+    }
+
+    if mismatches == 0 {
+        info!(groups = groups.len(), "OK — all group member counts match");
+    } else {
+        info!(mismatches, total = groups.len(), "group check complete");
+    }
+
+    Ok(())
+}

--- a/crates/indexer/src/commands/listen.rs
+++ b/crates/indexer/src/commands/listen.rs
@@ -85,8 +85,8 @@ async fn process_march_madness(
             .ok_or_else(|| eyre::eyre!("log missing block number"))?;
         let ts = p.get_block_timestamp(block_num).await?;
         let addr_str = format!("{address:#x}");
-        info!(event = "BracketSubmitted", addr = %addr_str, block = block_num);
-        redis_store::upsert_bracket_submitted(redis, &addr_str, block_num, ts).await?;
+        let is_new = redis_store::upsert_bracket_submitted(redis, &addr_str, block_num, ts).await?;
+        info!(event = "BracketSubmitted", addr = %addr_str, block = block_num, new = is_new);
         count += 1;
     }
 

--- a/crates/indexer/src/commands/mod.rs
+++ b/crates/indexer/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod backfill;
 pub mod check;
+pub mod check_redis;
 pub mod listen;
 pub mod reveal;

--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -109,21 +109,34 @@ enum Command {
         rpc_url: String,
     },
 
-    /// Sanity check: compare Redis entry count with on-chain getEntryCount()
+    /// Sanity check: compare Redis counts with on-chain contract state
     #[command(name = "check")]
     SanityCheck {
         /// JSON-RPC endpoint URL (falls back to VITE_RPC_URL env var)
         #[arg(long, env = "VITE_RPC_URL")]
         rpc_url: String,
     },
+
+    /// Redis-internal consistency check for stored counts (no RPC needed)
+    #[command(name = "check-redis")]
+    CheckRedis {
+        /// Check a specific group by slug
+        #[arg(long)]
+        group: Option<String>,
+
+        /// Check all groups
+        #[arg(long)]
+        all_groups: bool,
+    },
 }
 
-fn rpc_url(command: &Command) -> &str {
+fn rpc_url(command: &Command) -> Option<&str> {
     match command {
-        Command::Listen { rpc_url, .. }
+        Command::Listen { rpc_url }
         | Command::Backfill { rpc_url, .. }
-        | Command::Reveal { rpc_url, .. }
-        | Command::SanityCheck { rpc_url, .. } => rpc_url,
+        | Command::Reveal { rpc_url }
+        | Command::SanityCheck { rpc_url } => Some(rpc_url),
+        Command::CheckRedis { .. } => None,
     }
 }
 
@@ -177,13 +190,28 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let cli = Cli::parse();
-
-    let provider = match cli.network {
-        NetworkBackend::Reth => IndexerProvider::new_reth(rpc_url(&cli.command))?,
-        NetworkBackend::Foundry => IndexerProvider::new_foundry(rpc_url(&cli.command))?,
-    };
-
     let mut redis_conn = redis_store::connect().await?;
+
+    // check-redis is Redis-only — no provider or contract addresses needed.
+    if let Command::CheckRedis {
+        group, all_groups, ..
+    } = cli.command
+    {
+        let mode = if let Some(slug) = group {
+            commands::check_redis::CheckMode::Group(slug)
+        } else if all_groups {
+            commands::check_redis::CheckMode::AllGroups
+        } else {
+            commands::check_redis::CheckMode::Total
+        };
+        return commands::check_redis::run(&mut redis_conn, mode).await;
+    }
+
+    let rpc = rpc_url(&cli.command).expect("rpc_url required for this command");
+    let provider = match cli.network {
+        NetworkBackend::Reth => IndexerProvider::new_reth(rpc)?,
+        NetworkBackend::Foundry => IndexerProvider::new_foundry(rpc)?,
+    };
     let addrs = resolve_addresses(&cli)?.parse()?;
 
     match cli.command {
@@ -201,6 +229,7 @@ async fn main() -> Result<()> {
             let mm = format!("{:#x}", addrs.march_madness);
             commands::check::run(&provider, &mut redis_conn, &mm).await?;
         }
+        Command::CheckRedis { .. } => unreachable!(),
     }
 
     Ok(())

--- a/crates/indexer/src/redis_store.rs
+++ b/crates/indexer/src/redis_store.rs
@@ -45,18 +45,24 @@ async fn modify_hash_field<T: serde::Serialize + serde::de::DeserializeOwned>(
 // ── Entry operations ─────────────────────────────────────────────────
 
 /// Record a BracketSubmitted event.
+/// Returns `true` if this was a new entry (not an update).
 pub async fn upsert_bracket_submitted(
     conn: &mut MultiplexedConnection,
     address: &str,
     block: u64,
     timestamp: u64,
-) -> Result<()> {
+) -> Result<bool> {
     let addr = address.to_lowercase();
+    let is_new: bool = !conn.hexists(KEY_ENTRIES, &addr).await?;
     modify_hash_field(conn, KEY_ENTRIES, &addr, EntryData::default, |e| {
         e.block = block;
         e.ts = timestamp;
     })
-    .await
+    .await?;
+    if is_new {
+        let _: u64 = conn.incr(KEY_ENTRY_COUNT, 1u64).await?;
+    }
+    Ok(is_new)
 }
 
 /// Record a TagSet event: set the name field.
@@ -106,6 +112,7 @@ pub async fn create_group(
         creator: creator.to_lowercase(),
         has_password,
         members: Vec::new(),
+        member_count: 0,
     };
     let json = serde_json::to_string(&data)?;
     let id_str = group_id.to_string();
@@ -134,6 +141,7 @@ pub async fn member_joined(
     {
         if !group.members.contains(&addr) {
             group.members.push(addr);
+            group.member_count = group.members.len() as u32;
         }
         let json = serde_json::to_string(&group)?;
         let () = conn.hset(KEY_GROUPS, &id_str, &json).await?;
@@ -155,6 +163,7 @@ pub async fn member_left(
         .and_then(|s| serde_json::from_str::<GroupData>(s).ok())
     {
         group.members.retain(|a| a != &addr);
+        group.member_count = group.members.len() as u32;
         let json = serde_json::to_string(&group)?;
         let () = conn.hset(KEY_GROUPS, &id_str, &json).await?;
     }
@@ -242,4 +251,45 @@ pub async fn get_entry(
     let addr = address.to_lowercase();
     let json: Option<String> = conn.hget(KEY_ENTRIES, &addr).await?;
     Ok(json.and_then(|s| serde_json::from_str(&s).ok()))
+}
+
+/// Read the stored entry count counter.
+pub async fn get_stored_entry_count(conn: &mut MultiplexedConnection) -> Result<u64> {
+    let count: Option<u64> = conn.get(KEY_ENTRY_COUNT).await?;
+    Ok(count.unwrap_or(0))
+}
+
+/// Set the entry count counter (useful for manual correction).
+#[allow(dead_code)]
+pub async fn set_entry_count(conn: &mut MultiplexedConnection, count: u64) -> Result<()> {
+    let () = conn.set(KEY_ENTRY_COUNT, count).await?;
+    Ok(())
+}
+
+/// Get all groups from Redis.
+pub async fn get_all_groups(
+    conn: &mut MultiplexedConnection,
+) -> Result<std::collections::HashMap<String, GroupData>> {
+    let all: std::collections::HashMap<String, String> = conn.hgetall(KEY_GROUPS).await?;
+    let mut result = std::collections::HashMap::with_capacity(all.len());
+    for (id, json) in all {
+        if let Ok(data) = serde_json::from_str::<GroupData>(&json) {
+            result.insert(id, data);
+        }
+    }
+    Ok(result)
+}
+
+/// Get a single group by slug.
+pub async fn get_group_by_slug(
+    conn: &mut MultiplexedConnection,
+    slug: &str,
+) -> Result<Option<(String, GroupData)>> {
+    let id: Option<String> = conn.hget(KEY_GROUP_SLUGS, slug).await?;
+    let Some(id) = id else { return Ok(None) };
+    let json: Option<String> = conn.hget(KEY_GROUPS, &id).await?;
+    match json {
+        Some(s) => Ok(Some((id, serde_json::from_str(&s)?))),
+        None => Ok(None),
+    }
 }

--- a/crates/seismic-march-madness/src/redis_keys.rs
+++ b/crates/seismic-march-madness/src/redis_keys.rs
@@ -31,6 +31,9 @@ pub const KEY_MIRROR_SLUGS: &str = "mm:mirror:slugs";
 /// Mirror entries: "mirrorId:entrySlug" → bracket_hex (HASH).
 pub const KEY_MIRROR_ENTRIES: &str = "mm:mirror:entries";
 
+/// Total distinct bracket entry count for MarchMadness (STRING).
+pub const KEY_ENTRY_COUNT: &str = "mm:entry_count";
+
 /// Build a composite key for mirror entries: "mirrorId:entrySlug".
 pub fn mirror_entry_field(mirror_id: u64, slug: &str) -> String {
     format!("{mirror_id}:{slug}")
@@ -57,6 +60,8 @@ pub struct GroupData {
     pub creator: String,
     pub has_password: bool,
     pub members: Vec<String>,
+    #[serde(default)]
+    pub member_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -137,8 +137,8 @@ impl AppState {
 
     pub async fn get_entry_count(&self) -> Result<usize> {
         let mut conn = self.redis();
-        let count: usize = conn.hlen(KEY_ENTRIES).await?;
-        Ok(count)
+        let count: Option<usize> = conn.get(KEY_ENTRY_COUNT).await?;
+        Ok(count.unwrap_or(0))
     }
 
     // ── Group queries ────────────────────────────────────────────────
@@ -351,6 +351,6 @@ fn group_to_response(id: &str, data: &GroupData) -> GroupResponse {
         display_name: data.display_name.clone(),
         creator: data.creator.clone(),
         has_password: data.has_password,
-        member_count: data.members.len(),
+        member_count: data.member_count as usize,
     }
 }

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,14 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Denormalized entry count counters in Redis
+- **Indexer**: New `mm:entry_count` Redis key (STRING) tracks total distinct bracket entries via `INCR` on new submissions. Bracket updates (`updateBracket`) do not double-count — uses `HEXISTS` check.
+- **Indexer**: `GroupData` now has `member_count` field, updated atomically with `members` vec on join/leave.
+- **Indexer**: Backfill sanity check now verifies counter key vs HLEN vs on-chain, plus all group `member_count` vs `members.len()`.
+- **Indexer**: New `check-redis` subcommand for Redis-internal consistency checks (no RPC needed): `--total` (default), `--group <slug>`, `--all-groups`.
+- **Indexer**: Existing `check` subcommand now also compares counter key vs HLEN (in addition to on-chain).
+- **Server**: `GET /stats` reads from `mm:entry_count` instead of HLEN. `GET /groups` reads `member_count` from group metadata.
+
 ### 2026-03-16 — Use on-chain submission deadline instead of hardcoded constant (#113)
 - **Web**: Added `useSubmissionDeadline` hook that reads `submissionDeadline()` from the MarchMadness contract, falling back to the hardcoded constant if the contract read fails.
 - **Web**: `useContract` hook now exposes `submissionDeadline` (number, seconds) and a reactive `isBeforeDeadline` that updates every second.

--- a/docs/prompts/cdai__entry-count-counters/1742243100-add-entry-count-counters.txt
+++ b/docs/prompts/cdai__entry-count-counters/1742243100-add-entry-count-counters.txt
@@ -1,0 +1,9 @@
+in our api server, we should have an endpoint to return: the total count of all brackets in the MarchMadness contract, and the total count of entries in each group.
+
+these will be called often, so we should update our listener to store them as a field in redis. i am guessing we need a new key for the count of overall brackets, can just be a simply key  => value
+
+for groups, we should be storing this in the group meta, and updating each time we have a new distinct entry in the group
+
+it's okay if your code changes would make this calculation incorrect if we were to run listenr right away; i will run a flushdb + backfill once we merge this. the important thing is that future runs of listener don't double count entries. the obvious edge case to consider is when someone simply updates their bracket.
+
+we should have a sanity check after backfill completes, to make sure each group we've processed is consistent with however we're storing group entries; we should also have a sanity cehck on the overall count. and there should be a separate indexer subcommand that sanity checks the stored counts with either --total (default), a specific group --group, or all groups --all-groups. note that i might run the sanity check while listener is going, so you'll have to be wise about atomicity

--- a/docs/prompts/cdai__entry-count-counters/1742243200-rename-check-counts.txt
+++ b/docs/prompts/cdai__entry-count-counters/1742243200-rename-check-counts.txt
@@ -1,0 +1,1 @@
+can we rename the check-counts subcommand to include something so it's clear that it just checks vs. redis?


### PR DESCRIPTION
## Summary
- New `mm:entry_count` Redis key (STRING) tracks total distinct bracket entries via `INCR`. Bracket updates don't double-count (`HEXISTS` check before increment).
- `GroupData` now has `member_count` field, updated atomically with `members` vec on join/leave.
- New `check-redis` subcommand for Redis-internal consistency checks (no RPC): `--total` (default), `--group <slug>`, `--all-groups`.
- Existing `check` subcommand now also verifies counter key vs HLEN vs on-chain.
- Server `GET /stats` reads from counter key; `GET /groups` reads `member_count` from group metadata.

**Requires `flushdb` + `backfill` after merge** — the INCR-based counter starts from 0 on fresh Redis.

## API routes (no new routes, existing ones now backed by counters)
- `GET /stats` → `{ total_entries, scored }` — reads `mm:entry_count`
- `GET /groups` → list with `member_count` per group — reads `GroupData.member_count`
- `GET /groups/:slug` → single group with `member_count`

## Test plan
- [ ] `flushdb` + `backfill` on testnet
- [ ] Run `check` to verify counter vs HLEN vs on-chain
- [ ] Run `check-redis --all-groups` to verify group member counts
- [ ] Submit a new bracket, verify counter increments
- [ ] Update existing bracket, verify counter does NOT increment
- [ ] Join/leave group, verify `member_count` updates