### PR TITLE
Fix group/mirror event ordering: sort by (block, log_index)

### DIFF
--- a/crates/indexer/src/commands/backfill.rs
+++ b/crates/indexer/src/commands/backfill.rs
@@ -3,12 +3,18 @@
 use crate::ParsedAddresses;
 use crate::provider::{self, IndexerProvider};
 use crate::redis_store;
+use alloy_rpc_types_eth::Log;
 use eyre::{Result, WrapErr};
 use redis::aio::MultiplexedConnection;
 use tracing::info;
 
 /// Maximum block range per eth_getLogs request.
 const BATCH_SIZE: u64 = 10_000;
+
+/// Sort key for ordering events: (block_number, log_index).
+fn log_sort_key(log: &Log) -> (u64, u64) {
+    (log.block_number.unwrap_or(0), log.log_index.unwrap_or(0))
+}
 
 pub async fn run(
     p: &IndexerProvider,
@@ -91,7 +97,7 @@ pub async fn run(
         from = to + 1;
     }
 
-    // ── Pass 3: BracketGroups ────────────────────────────────────────
+    // ── Pass 3: BracketGroups (sorted by block + log_index) ─────────
     {
         let groups = groups_addr;
         info!("scanning BracketGroups events");
@@ -99,37 +105,50 @@ pub async fn run(
         while from <= latest_block {
             let to = std::cmp::min(from + BATCH_SIZE - 1, latest_block);
 
-            // GroupCreated
             let created = p.get_group_created_logs(groups, from, to).await?;
-            for log in &created {
-                let (id, slug, display_name, creator, has_password) =
-                    provider::parse_group_created(log)?;
-                let creator_str = format!("{creator:#x}");
-                redis_store::create_group(
-                    redis,
-                    id,
-                    &slug,
-                    &display_name,
-                    &creator_str,
-                    has_password,
-                )
-                .await?;
-            }
-
-            // MemberJoined
             let joined = p.get_member_joined_logs(groups, from, to).await?;
-            for log in &joined {
-                let (id, addr) = provider::parse_member_joined(log)?;
-                let addr_str = format!("{addr:#x}");
-                redis_store::member_joined(redis, id, &addr_str).await?;
-            }
-
-            // MemberLeft
             let left = p.get_member_left_logs(groups, from, to).await?;
+
+            let mut events: Vec<((u64, u64), GroupEvent)> =
+                Vec::with_capacity(created.len() + joined.len() + left.len());
+            for log in &created {
+                events.push((log_sort_key(log), GroupEvent::Created(log)));
+            }
+            for log in &joined {
+                events.push((log_sort_key(log), GroupEvent::Joined(log)));
+            }
             for log in &left {
-                let (id, addr) = provider::parse_member_left(log)?;
-                let addr_str = format!("{addr:#x}");
-                redis_store::member_left(redis, id, &addr_str).await?;
+                events.push((log_sort_key(log), GroupEvent::Left(log)));
+            }
+            events.sort_by_key(|(key, _)| *key);
+
+            for (_, event) in &events {
+                match event {
+                    GroupEvent::Created(log) => {
+                        let (id, slug, display_name, creator, has_password) =
+                            provider::parse_group_created(log)?;
+                        let creator_str = format!("{creator:#x}");
+                        redis_store::create_group(
+                            redis,
+                            id,
+                            &slug,
+                            &display_name,
+                            &creator_str,
+                            has_password,
+                        )
+                        .await?;
+                    }
+                    GroupEvent::Joined(log) => {
+                        let (id, addr) = provider::parse_member_joined(log)?;
+                        let addr_str = format!("{addr:#x}");
+                        redis_store::member_joined(redis, id, &addr_str).await?;
+                    }
+                    GroupEvent::Left(log) => {
+                        let (id, addr) = provider::parse_member_left(log)?;
+                        let addr_str = format!("{addr:#x}");
+                        redis_store::member_left(redis, id, &addr_str).await?;
+                    }
+                }
             }
 
             let total = created.len() + joined.len() + left.len();
@@ -146,7 +165,7 @@ pub async fn run(
         }
     }
 
-    // ── Pass 4: BracketMirror ────────────────────────────────────────
+    // ── Pass 4: BracketMirror (sorted by block + log_index) ─────────
     {
         let mirror = mirror_addr;
         info!("scanning BracketMirror events");
@@ -154,40 +173,60 @@ pub async fn run(
         while from <= latest_block {
             let to = std::cmp::min(from + BATCH_SIZE - 1, latest_block);
 
-            // MirrorCreated
             let created = p.get_mirror_created_logs(mirror, from, to).await?;
-            for log in &created {
-                let (id, slug, display_name, admin) = provider::parse_mirror_created(log)?;
-                let admin_str = format!("{admin:#x}");
-                redis_store::create_mirror(redis, id, &slug, &display_name, &admin_str).await?;
-            }
-
-            // EntryAdded
             let added = p.get_entry_added_logs(mirror, from, to).await?;
+            let removed = p.get_entry_removed_logs(mirror, from, to).await?;
+
+            let mut events: Vec<((u64, u64), MirrorEvent)> =
+                Vec::with_capacity(created.len() + added.len() + removed.len());
+            for log in &created {
+                events.push((log_sort_key(log), MirrorEvent::Created(log)));
+            }
             for log in &added {
-                let (mirror_id, slug) = provider::parse_entry_added(log)?;
-                let u256_id = alloy_primitives::U256::from(mirror_id);
-                match p
-                    .get_mirror_entry_bracket(mirror, u256_id, slug.clone())
-                    .await
-                {
-                    Ok(bracket) => {
-                        let bracket_hex = format!("0x{}", hex::encode(bracket.as_slice()));
-                        redis_store::mirror_entry_added(redis, mirror_id, &slug, &bracket_hex)
+                events.push((log_sort_key(log), MirrorEvent::Added(log)));
+            }
+            for log in &removed {
+                events.push((log_sort_key(log), MirrorEvent::Removed(log)));
+            }
+            events.sort_by_key(|(key, _)| *key);
+
+            for (_, event) in &events {
+                match event {
+                    MirrorEvent::Created(log) => {
+                        let (id, slug, display_name, admin) = provider::parse_mirror_created(log)?;
+                        let admin_str = format!("{admin:#x}");
+                        redis_store::create_mirror(redis, id, &slug, &display_name, &admin_str)
                             .await?;
                     }
-                    Err(e) => {
-                        info!(mirror_id, slug = %slug, error = %e, "failed to read mirror entry bracket");
-                        redis_store::mirror_entry_added(redis, mirror_id, &slug, "").await?;
+                    MirrorEvent::Added(log) => {
+                        let (mirror_id, slug) = provider::parse_entry_added(log)?;
+                        let u256_id = alloy_primitives::U256::from(mirror_id);
+                        match p
+                            .get_mirror_entry_bracket(mirror, u256_id, slug.clone())
+                            .await
+                        {
+                            Ok(bracket) => {
+                                let bracket_hex = format!("0x{}", hex::encode(bracket.as_slice()));
+                                redis_store::mirror_entry_added(
+                                    redis,
+                                    mirror_id,
+                                    &slug,
+                                    &bracket_hex,
+                                )
+                                .await?;
+                            }
+                            Err(e) => {
+                                info!(mirror_id, slug = %slug, error = %e, "failed to read mirror entry bracket");
+                                redis_store::mirror_entry_added(redis, mirror_id, &slug, "")
+                                    .await?;
+                            }
+                        }
+                    }
+                    MirrorEvent::Removed(log) => {
+                        let (mirror_id, slug) = provider::parse_entry_removed(log)?;
+                        redis_store::mirror_entry_removed(redis, mirror_id, &slug).await?;
                     }
                 }
-            }
-
-            // EntryRemoved
-            let removed = p.get_entry_removed_logs(mirror, from, to).await?;
-            for log in &removed {
-                let (mirror_id, slug) = provider::parse_entry_removed(log)?;
-                redis_store::mirror_entry_removed(redis, mirror_id, &slug).await?;
             }
 
             let total = created.len() + added.len() + removed.len();
@@ -224,4 +263,18 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+// ── Tagged event enums for sort-then-process ────────────────────────
+
+enum GroupEvent<'a> {
+    Created(&'a Log),
+    Joined(&'a Log),
+    Left(&'a Log),
+}
+
+enum MirrorEvent<'a> {
+    Created(&'a Log),
+    Added(&'a Log),
+    Removed(&'a Log),
 }

--- a/crates/indexer/src/commands/listen.rs
+++ b/crates/indexer/src/commands/listen.rs
@@ -4,6 +4,7 @@ use crate::ParsedAddresses;
 use crate::provider::{self, IndexerProvider};
 use crate::redis_store;
 use alloy_primitives::Address;
+use alloy_rpc_types_eth::Log;
 use eyre::{Result, WrapErr};
 use redis::aio::MultiplexedConnection;
 use tokio::signal;
@@ -11,6 +12,11 @@ use tracing::info;
 
 /// Poll interval in seconds.
 const POLL_INTERVAL_SECS: u64 = 5;
+
+/// Sort key for ordering events: (block_number, log_index).
+fn log_sort_key(log: &Log) -> (u64, u64) {
+    (log.block_number.unwrap_or(0), log.log_index.unwrap_or(0))
+}
 
 pub async fn run(
     p: &IndexerProvider,
@@ -106,6 +112,14 @@ async fn process_march_madness(
     Ok(count)
 }
 
+// ── Group events, sorted by (block, log_index) ─────────────────────
+
+enum GroupEvent<'a> {
+    Created(&'a Log),
+    Joined(&'a Log),
+    Left(&'a Log),
+}
+
 async fn process_groups(
     p: &IndexerProvider,
     redis: &mut MultiplexedConnection,
@@ -113,37 +127,66 @@ async fn process_groups(
     from: u64,
     to: u64,
 ) -> Result<u32> {
-    let mut count = 0u32;
-
     let created_logs = p.get_group_created_logs(contract, from, to).await?;
-    for log in &created_logs {
-        let (id, slug, display_name, creator, has_password) = provider::parse_group_created(log)?;
-        let creator_str = format!("{creator:#x}");
-        info!(event = "GroupCreated", id, slug = %slug);
-        redis_store::create_group(redis, id, &slug, &display_name, &creator_str, has_password)
-            .await?;
-        count += 1;
-    }
-
     let joined_logs = p.get_member_joined_logs(contract, from, to).await?;
-    for log in &joined_logs {
-        let (id, addr) = provider::parse_member_joined(log)?;
-        let addr_str = format!("{addr:#x}");
-        info!(event = "MemberJoined", group_id = id, addr = %addr_str);
-        redis_store::member_joined(redis, id, &addr_str).await?;
-        count += 1;
-    }
-
     let left_logs = p.get_member_left_logs(contract, from, to).await?;
+
+    let mut events: Vec<((u64, u64), GroupEvent)> =
+        Vec::with_capacity(created_logs.len() + joined_logs.len() + left_logs.len());
+    for log in &created_logs {
+        events.push((log_sort_key(log), GroupEvent::Created(log)));
+    }
+    for log in &joined_logs {
+        events.push((log_sort_key(log), GroupEvent::Joined(log)));
+    }
     for log in &left_logs {
-        let (id, addr) = provider::parse_member_left(log)?;
-        let addr_str = format!("{addr:#x}");
-        info!(event = "MemberLeft", group_id = id, addr = %addr_str);
-        redis_store::member_left(redis, id, &addr_str).await?;
+        events.push((log_sort_key(log), GroupEvent::Left(log)));
+    }
+    events.sort_by_key(|(key, _)| *key);
+
+    let mut count = 0u32;
+    for (_, event) in &events {
+        match event {
+            GroupEvent::Created(log) => {
+                let (id, slug, display_name, creator, has_password) =
+                    provider::parse_group_created(log)?;
+                let creator_str = format!("{creator:#x}");
+                info!(event = "GroupCreated", id, slug = %slug);
+                redis_store::create_group(
+                    redis,
+                    id,
+                    &slug,
+                    &display_name,
+                    &creator_str,
+                    has_password,
+                )
+                .await?;
+            }
+            GroupEvent::Joined(log) => {
+                let (id, addr) = provider::parse_member_joined(log)?;
+                let addr_str = format!("{addr:#x}");
+                info!(event = "MemberJoined", group_id = id, addr = %addr_str);
+                redis_store::member_joined(redis, id, &addr_str).await?;
+            }
+            GroupEvent::Left(log) => {
+                let (id, addr) = provider::parse_member_left(log)?;
+                let addr_str = format!("{addr:#x}");
+                info!(event = "MemberLeft", group_id = id, addr = %addr_str);
+                redis_store::member_left(redis, id, &addr_str).await?;
+            }
+        }
         count += 1;
     }
 
     Ok(count)
+}
+
+// ── Mirror events, sorted by (block, log_index) ────────────────────
+
+enum MirrorEvent<'a> {
+    Created(&'a Log),
+    Added(&'a Log),
+    Removed(&'a Log),
 }
 
 async fn process_mirror(
@@ -153,44 +196,57 @@ async fn process_mirror(
     from: u64,
     to: u64,
 ) -> Result<u32> {
-    let mut count = 0u32;
-
     let created_logs = p.get_mirror_created_logs(contract, from, to).await?;
-    for log in &created_logs {
-        let (id, slug, display_name, admin) = provider::parse_mirror_created(log)?;
-        let admin_str = format!("{admin:#x}");
-        info!(event = "MirrorCreated", id, slug = %slug);
-        redis_store::create_mirror(redis, id, &slug, &display_name, &admin_str).await?;
-        count += 1;
-    }
-
     let added_logs = p.get_entry_added_logs(contract, from, to).await?;
+    let removed_logs = p.get_entry_removed_logs(contract, from, to).await?;
+
+    let mut events: Vec<((u64, u64), MirrorEvent)> =
+        Vec::with_capacity(created_logs.len() + added_logs.len() + removed_logs.len());
+    for log in &created_logs {
+        events.push((log_sort_key(log), MirrorEvent::Created(log)));
+    }
     for log in &added_logs {
-        let (mirror_id, slug) = provider::parse_entry_added(log)?;
-        // Fetch bracket from contract.
-        let u256_id = alloy_primitives::U256::from(mirror_id);
-        match p
-            .get_mirror_entry_bracket(contract, u256_id, slug.clone())
-            .await
-        {
-            Ok(bracket) => {
-                let bracket_hex = format!("0x{}", hex::encode(bracket.as_slice()));
-                info!(event = "EntryAdded", mirror_id, slug = %slug, bracket = %bracket_hex);
-                redis_store::mirror_entry_added(redis, mirror_id, &slug, &bracket_hex).await?;
+        events.push((log_sort_key(log), MirrorEvent::Added(log)));
+    }
+    for log in &removed_logs {
+        events.push((log_sort_key(log), MirrorEvent::Removed(log)));
+    }
+    events.sort_by_key(|(key, _)| *key);
+
+    let mut count = 0u32;
+    for (_, event) in &events {
+        match event {
+            MirrorEvent::Created(log) => {
+                let (id, slug, display_name, admin) = provider::parse_mirror_created(log)?;
+                let admin_str = format!("{admin:#x}");
+                info!(event = "MirrorCreated", id, slug = %slug);
+                redis_store::create_mirror(redis, id, &slug, &display_name, &admin_str).await?;
             }
-            Err(e) => {
-                info!(event = "EntryAdded", mirror_id, slug = %slug, error = %e, "failed to read bracket, storing without it");
-                redis_store::mirror_entry_added(redis, mirror_id, &slug, "").await?;
+            MirrorEvent::Added(log) => {
+                let (mirror_id, slug) = provider::parse_entry_added(log)?;
+                let u256_id = alloy_primitives::U256::from(mirror_id);
+                match p
+                    .get_mirror_entry_bracket(contract, u256_id, slug.clone())
+                    .await
+                {
+                    Ok(bracket) => {
+                        let bracket_hex = format!("0x{}", hex::encode(bracket.as_slice()));
+                        info!(event = "EntryAdded", mirror_id, slug = %slug, bracket = %bracket_hex);
+                        redis_store::mirror_entry_added(redis, mirror_id, &slug, &bracket_hex)
+                            .await?;
+                    }
+                    Err(e) => {
+                        info!(event = "EntryAdded", mirror_id, slug = %slug, error = %e, "failed to read bracket, storing without it");
+                        redis_store::mirror_entry_added(redis, mirror_id, &slug, "").await?;
+                    }
+                }
+            }
+            MirrorEvent::Removed(log) => {
+                let (mirror_id, slug) = provider::parse_entry_removed(log)?;
+                info!(event = "EntryRemoved", mirror_id, slug = %slug);
+                redis_store::mirror_entry_removed(redis, mirror_id, &slug).await?;
             }
         }
-        count += 1;
-    }
-
-    let removed_logs = p.get_entry_removed_logs(contract, from, to).await?;
-    for log in &removed_logs {
-        let (mirror_id, slug) = provider::parse_entry_removed(log)?;
-        info!(event = "EntryRemoved", mirror_id, slug = %slug);
-        redis_store::mirror_entry_removed(redis, mirror_id, &slug).await?;
         count += 1;
     }
 

--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,9 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Fix group/mirror event ordering in indexer
+- **Indexer**: Group events (GroupCreated, MemberJoined, MemberLeft) and mirror events (MirrorCreated, EntryAdded, EntryRemoved) are now sorted by `(block_number, log_index)` before processing, instead of being grouped by event type. Fixes edge case where leave-then-rejoin within a single poll cycle or backfill batch could produce incorrect state.
+
 ### 2026-03-16 — Use on-chain submission deadline instead of hardcoded constant (#113)
 - **Web**: Added `useSubmissionDeadline` hook that reads `submissionDeadline()` from the MarchMadness contract, falling back to the hardcoded constant if the contract read fails.
 - **Web**: `useContract` hook now exposes `submissionDeadline` (number, seconds) and a reactive `isBeforeDeadline` that updates every second.

--- a/docs/prompts/cdai__event-ordering-fix/1742243900-fix-event-ordering.txt
+++ b/docs/prompts/cdai__event-ordering-fix/1742243900-fix-event-ordering.txt
@@ -1,0 +1,3 @@
+i think w eshould also treat the order of groupcreated vs member joined in the same way <-- order by block and then by log index
+
+fix it in this pr.


### PR DESCRIPTION
## Summary
- Group events (GroupCreated, MemberJoined, MemberLeft) and mirror events (MirrorCreated, EntryAdded, EntryRemoved) are now merged into a single list sorted by `(block_number, log_index)` before processing.
- Previously they were grouped by event type — all Created first, then all Joined, then all Left — which could produce incorrect state if a member left and re-joined within the same poll cycle or backfill batch.
- Applied to both `listen.rs` and `backfill.rs`.

Closes #151

## Test plan
- [ ] `flushdb` + `backfill` — verify sanity check passes
- [ ] Listener processes events correctly for new group creation (GroupCreated + MemberJoined for creator in same tx)