### PR TITLE
Rename 'Join Private Group' to 'Join Group'

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,11 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Rename "Join Private Group" to "Join Group"
+
+- **UI**: Renamed "Join Private Group" heading to "Join Group" and updated subtitle to be group-type-agnostic.
+- **UI**: "Private group" checkbox now defaults to checked, so users joining via invite links get the passphrase field by default.
+
 ### 2026-03-17 — Fix public group joins failing when passphrase field is non-empty
 
 - **UI**: Replaced the always-visible passphrase input with a "Private group" toggle checkbox. Passphrase field only appears when the toggle is on, and `handleJoin()` uses the toggle state (not input text or API-resolved group type) to choose between `joinGroup` and `joinGroupWithPassword`. This eliminates the bug where leftover passphrase text caused public group joins to revert with `GroupIsNotPasswordProtected`.

--- a/docs/prompts/cdai__rename-join-group-section/1742220000-rename-join-group.txt
+++ b/docs/prompts/cdai__rename-join-group-section/1742220000-rename-join-group.txt
@@ -1,0 +1,1 @@
+"Join Private Group" section should be named "Join Group". But "Private group" checkmark should be default on.

--- a/packages/web/src/components/PrivateJoinForm.tsx
+++ b/packages/web/src/components/PrivateJoinForm.tsx
@@ -21,7 +21,7 @@ export function PrivateJoinForm({
 }: PrivateJoinFormProps) {
   const [slugInput, setSlugInput] = useState(initialSlug);
   const [nameInput, setNameInput] = useState("");
-  const [isPrivateJoin, setIsPrivateJoin] = useState(!!initialPassphrase);
+  const [isPrivateJoin, setIsPrivateJoin] = useState(true);
   const [passphraseInput, setPassphraseInput] = useState(initialPassphrase);
   const [joinError, setJoinError] = useState<string | null>(null);
 
@@ -79,11 +79,10 @@ export function PrivateJoinForm({
   return (
     <div className="rounded-xl bg-bg-secondary border border-border p-4 sm:p-6">
       <h2 className="text-lg font-semibold text-text-primary mb-1">
-        Join Private Group
+        Join Group
       </h2>
       <p className="text-sm text-text-muted mb-4">
-        Have an invite link or slug? Enter it here with the passphrase to join a
-        private group.
+        Have an invite link or slug? Enter it here to join a group.
       </p>
 
       <div className="space-y-2 max-w-md">


### PR DESCRIPTION
## Summary

- Renamed the "Join Private Group" heading to "Join Group" and updated the subtitle to be group-type-agnostic.
- Changed the "Private group" checkbox default from off (only on when `initialPassphrase` was set) to always on, so the passphrase field shows by default.

## Test plan

- [ ] Visit `/groups` page and verify the section heading says "Join Group"
- [ ] Verify the subtitle reads "Have an invite link or slug? Enter it here to join a group."
- [ ] Verify the "Private group" checkbox is checked by default
- [ ] Join a private group with passphrase — should work as before
- [ ] Uncheck the checkbox and join a public group — should work as before