### PR TITLE
Add bracket submission counter on home page

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,10 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Bracket submission counter on home page
+
+- **UI**: Added a bracket count indicator next to the deadline countdown on the home page, showing how many brackets have been submitted. Fetches from the `/stats` API endpoint, polls every 30s. Gracefully hidden when the API is unavailable.
+
 ### 2026-03-17 — Groups page polish
 
 - **UI**: Simplified mobile tab labels: "Your Groups" → "Yours", "Public Groups" → "Public", "Join Group" → "Join", "Create Group" → "Create".

--- a/docs/prompts/cdai__bracket-counter/1773766651-bracket-counter.txt
+++ b/docs/prompts/cdai__bracket-counter/1773766651-bracket-counter.txt
@@ -1,0 +1,2 @@
+on the main page, immediately to the right of "Brackets lock in ___":
+- add a simple counter for how many brackets have been submitted to the marchmadness contract. i think we store this in redis and expose it via the api.

--- a/packages/web/src/hooks/useStats.ts
+++ b/packages/web/src/hooks/useStats.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:3000";
+const POLL_INTERVAL = 30_000; // 30s
+
+export function useStats() {
+  const [totalEntries, setTotalEntries] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data: { total_entries: number; scored: number } = await res.json();
+        setTotalEntries(data.total_entries);
+        setError(null);
+      } else {
+        setError(`Failed to fetch stats: ${res.status}`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch_();
+    const id = setInterval(fetch_, POLL_INTERVAL);
+    return () => clearInterval(id);
+  }, [fetch_]);
+
+  return { totalEntries, loading, error };
+}

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import { FaucetBanner } from "../components/FaucetBanner";
 import { SubmitPanel } from "../components/SubmitPanel";
 import { useBracket } from "../hooks/useBracket";
 import { useContract } from "../hooks/useContract";
+import { useStats } from "../hooks/useStats";
 import { useTournamentStatus } from "../hooks/useTournamentStatus";
 
 export function HomePage() {
@@ -15,6 +16,7 @@ export function HomePage() {
   const contract = useContract();
   const bracket = useBracket(contract.walletAddress);
   const { status: tournamentStatus } = useTournamentStatus();
+  const { totalEntries, loading: statsLoading, error: statsError } = useStats();
 
   const isLocked = !contract.isBeforeDeadline;
   const [resetOpen, setResetOpen] = useState(false);
@@ -114,6 +116,14 @@ export function HomePage() {
 
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
         <DeadlineCountdown deadline={contract.submissionDeadline} />
+        {!statsLoading && !statsError && totalEntries != null && (
+          <div className="rounded-lg px-4 py-2 text-center bg-bg-tertiary border border-border">
+            <div className="text-xs text-text-muted mb-1">Brackets</div>
+            <div className="font-mono font-bold text-sm text-text-primary">
+              {totalEntries}
+            </div>
+          </div>
+        )}
         {!isLocked && (
           <>
             <button


### PR DESCRIPTION
## Summary

- Added a `useStats()` hook that fetches from the `/stats` API endpoint (polls every 30s), matching the existing `useEntries` pattern
- Shows a small "Brackets: N" counter immediately to the right of the deadline countdown on the home page
- Styled to match the countdown component (same `rounded-lg`, `bg-bg-tertiary`, `border-border`)
- Gracefully hidden when the API is unavailable (loading or error state)

## Test plan

- [ ] Verify counter appears next to countdown when API server is running
- [ ] Verify counter updates when new brackets are submitted
- [ ] Verify nothing renders when API server is down (no error shown to user)
- [ ] Verify layout looks correct on mobile and desktop