### PR TITLE
Fix submit bracket button UX: cursor + wallet init

### DIFF
--- a/docs/changeset.md
+++ b/docs/changeset.md
@@ -4,6 +4,12 @@ All notable changes to this project. Every PR must add an entry here.
 
 ## [Unreleased]
 
+### 2026-03-17 — Fix submit bracket button UX
+
+- **UI**: Added `cursor-pointer` to the submit/update bracket button on both desktop and mobile so it shows the hand icon when hoverable.
+- **Fix**: Submit button now correctly reflects wallet readiness — disabled until the wallet client is fully initialized, not just when Privy auth is active. Prevents silent failures when `authenticated` is true but the embedded wallet hasn't loaded yet.
+- **Fix**: `submitBracket`, `updateBracket`, and `setTag` now display a visible error message ("Wallet not connected") instead of silently failing when the wallet client isn't ready.
+
 ### 2026-03-17 — Bracket submission counter on home page
 
 - **UI**: Added a bracket count indicator next to the deadline countdown on the home page, showing how many brackets have been submitted. Fetches from the `/stats` API endpoint, polls every 30s. Gracefully hidden when the API is unavailable.

--- a/docs/prompts/cdai__fix-submit-button/1742243400-fix-submit-button.txt
+++ b/docs/prompts/cdai__fix-submit-button/1742243400-fix-submit-button.txt
@@ -1,0 +1,5 @@
+hey a guy at the office is having trouble clicking "Submit bracket" on the ui. i'm unable to reproduce this locally. but first: i noticed that button doesnt have the intuitive pointer icon (both for me when it works and for him when it doesnt)
+
+so first fix that, should be easy
+
+but then when youre around that part of the code -- figure out why he's unable to press the submit button. i couldnt reproduce, i'm using same browser and also logged in with same method

--- a/packages/web/src/components/SubmitPanel.tsx
+++ b/packages/web/src/components/SubmitPanel.tsx
@@ -176,8 +176,8 @@ export function SubmitPanel({
                 : isLoading
                   ? "bg-accent/50 text-white cursor-wait"
                   : submitSuccess
-                    ? "bg-success text-white ring-2 ring-success/30"
-                    : "bg-accent text-white hover:bg-accent-hover ring-2 ring-accent/30"
+                    ? "bg-success text-white ring-2 ring-success/30 cursor-pointer"
+                    : "bg-accent text-white hover:bg-accent-hover ring-2 ring-accent/30 cursor-pointer"
             }`}
           >
             {isLoading
@@ -319,8 +319,8 @@ function MobileSubmitPanel({
               : isLoading
                 ? "bg-accent/50 text-white cursor-wait"
                 : submitSuccess
-                  ? "bg-success text-white"
-                  : "bg-accent text-white hover:bg-accent-hover"
+                  ? "bg-success text-white cursor-pointer"
+                  : "bg-accent text-white hover:bg-accent-hover cursor-pointer"
           }`}
         >
           {isLoading

--- a/packages/web/src/hooks/useContract.ts
+++ b/packages/web/src/hooks/useContract.ts
@@ -205,7 +205,10 @@ export function useContract() {
   // Submit bracket (shielded write via client library)
   const submitBracket = useCallback(
     async (bracketHex: `0x${string}`) => {
-      if (!mmUser) throw new Error("Wallet not connected");
+      if (!mmUser) {
+        setError("Wallet not connected — please wait for your wallet to initialize or try reconnecting.");
+        return;
+      }
       setIsLoading(true);
       setError(null);
 
@@ -230,7 +233,10 @@ export function useContract() {
   // Update bracket (shielded write, no additional fee)
   const updateBracket = useCallback(
     async (bracketHex: `0x${string}`) => {
-      if (!mmUser) throw new Error("Wallet not connected");
+      if (!mmUser) {
+        setError("Wallet not connected — please wait for your wallet to initialize or try reconnecting.");
+        return;
+      }
       setIsLoading(true);
       setError(null);
 
@@ -252,7 +258,10 @@ export function useContract() {
   // Set tag (transparent write via client library)
   const setTag = useCallback(
     async (tag: string) => {
-      if (!mmUser) throw new Error("Wallet not connected");
+      if (!mmUser) {
+        setError("Wallet not connected — please wait for your wallet to initialize or try reconnecting.");
+        return;
+      }
       setIsLoading(true);
       setError(null);
 

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -235,7 +235,7 @@ export function HomePage() {
         <SubmitPanel
           contract={contract}
           bracket={bracket}
-          walletConnected={authenticated}
+          walletConnected={authenticated && !!contract.walletAddress}
           onLoadBracket={handleLoadBracket}
         />
       </div>


### PR DESCRIPTION
## Summary

- Added `cursor-pointer` to the submit/update bracket button (desktop + mobile) so it shows the hand icon
- Fixed `walletConnected` to check both Privy `authenticated` AND `contract.walletAddress` — prevents the button from appearing enabled before the embedded wallet has initialized
- Changed `submitBracket`/`updateBracket`/`setTag` to display a visible error ("Wallet not connected") instead of silently throwing when `mmUser` is null (the throw was outside the try/catch that sets error state)

The likely root cause for the reported issue: Privy reports `authenticated = true` before `walletClient` from `useShieldedWallet()` is ready. The button looked enabled, but clicking it hit the `if (!mmUser) throw` guard which was outside the error-display try/catch — so the click silently did nothing.

## Test plan

- [ ] Log in, verify submit button shows pointer cursor when enabled
- [ ] Test with the coworker who was unable to submit — see if the error message now appears, or if the wallet init fix resolves it
- [ ] Verify normal submit flow still works end-to-end