### PR TITLE
Restore submitted bracket count

### DIFF
--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -42,8 +42,18 @@ export function HomePage() {
         />
       </div>
 
-      <div className="flex justify-center mb-6 sm:mb-8">
+      <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4 mb-6 sm:mb-8">
         <DeadlineCountdown deadline={contract.submissionDeadline} />
+        {!statsLoading && !statsError && totalEntries != null && (
+          <div className="rounded-lg px-4 py-2 text-center bg-bg-tertiary border border-border">
+            <div className="text-xs text-text-muted mb-1">
+              Brackets submitted
+            </div>
+            <div className="font-mono font-bold text-sm text-text-primary">
+              {totalEntries}
+            </div>
+          </div>
+        )}
       </div>
 
       <BracketView


### PR DESCRIPTION
## Summary
- restore the submitted bracket count badge on the home page
- keep the countdown and count grouped together again
- leave the contract-hex UI unchanged in this PR

## Testing
- bun run --filter @march-madness/web build