### PR TITLE
feat(web): add Score Bracket UI to leaderboard and bracket viewer

### DIFF
--- a/.changeset/score-bracket-ui.md
+++ b/.changeset/score-bracket-ui.md
@@ -1,0 +1,5 @@
+---
+"@march-madness/web": minor
+---
+
+Add Score Bracket UI — "Score My Bracket" button on the leaderboard scoring banner and "Score Bracket" button on the bracket viewer page. Both call `scoreBracket(address)` on-chain during the 7-day scoring window.

--- a/docs/prompts/score-bracket-ui/1775663752-score-bracket-ui.txt
+++ b/docs/prompts/score-bracket-ui/1775663752-score-bracket-ui.txt
@@ -1,0 +1,5 @@
+we need to create a scoreBracket() funcitonality in the contract so a user can see how their bracket did
+
+we should put a button on the Bracket page and the Leaderboard page,
+
+we currently calculate this off chain, and need a user interface for the user to score this

--- a/packages/web/src/components/WinningsBanner.tsx
+++ b/packages/web/src/components/WinningsBanner.tsx
@@ -38,6 +38,12 @@ export function WinningsBanner({ type, state }: WinningsBannerProps) {
     error,
   } = state;
 
+  const canScore = type === "main" ? (state as WinningsState).canScore : false;
+  const scoreBracket =
+    type === "main" ? (state as WinningsState).scoreBracket : null;
+  const isScoring =
+    type === "main" ? (state as WinningsState).isScoring : false;
+
   // Nothing to show until results are posted
   if (!resultsPostedAt || resultsPostedAt === 0n) return null;
 
@@ -144,6 +150,16 @@ export function WinningsBanner({ type, state }: WinningsBannerProps) {
 
   // ── Scoring window open ──────────────────────────────────────────
   if (isWindowOpen && scoringWindowClosesAt !== null) {
+    const handleScore = async () => {
+      if (!scoreBracket) return;
+      try {
+        const hash = await scoreBracket();
+        setTxHash(hash);
+      } catch {
+        // error already set in hook state
+      }
+    };
+
     return (
       <div className="bg-bg-secondary border border-border rounded-xl p-4 sm:p-5 mb-4 sm:mb-6">
         <div className="text-sm font-semibold text-text-primary mb-1">
@@ -153,6 +169,25 @@ export function WinningsBanner({ type, state }: WinningsBannerProps) {
           Scoring window closes {formatDate(scoringWindowClosesAt)}. Winners can
           claim their prize after scoring completes.
         </p>
+        {canScore && (
+          <div className="mt-3">
+            {error && <p className="text-xs text-red-400 mb-2">{error}</p>}
+            {txHash ? (
+              <p className="text-xs text-success font-mono">
+                Transaction sent: {truncateHash(txHash)}
+              </p>
+            ) : (
+              <button
+                type="button"
+                onClick={handleScore}
+                disabled={isScoring}
+                className="px-4 py-1.5 rounded-lg bg-accent text-bg-primary font-semibold text-xs sm:text-sm hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isScoring ? "Scoring..." : "Score My Bracket"}
+              </button>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/web/src/hooks/useBracketScoringState.ts
+++ b/packages/web/src/hooks/useBracketScoringState.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useShieldedWallet } from "seismic-react";
+import {
+  MarchMadnessPublicClient,
+  MarchMadnessUserClient,
+} from "@march-madness/client";
+import type { Address } from "viem";
+
+import { CONTRACT_ADDRESS } from "../lib/constants";
+
+const SCORING_DURATION = 7n * 24n * 3600n; // 7 days in seconds
+
+function nowSeconds(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000));
+}
+
+export interface BracketScoringState {
+  isScored: boolean;
+  canScore: boolean;
+  scoreBracket: () => Promise<`0x${string}`>;
+  isScoring: boolean;
+  error: string | null;
+  isLoading: boolean;
+}
+
+export function useBracketScoringState(
+  targetAddress: string | undefined
+): BracketScoringState {
+  const { authenticated } = usePrivy();
+  const { walletClient, publicClient } = useShieldedWallet();
+
+  const [resultsPostedAt, setResultsPostedAt] = useState<bigint | null>(null);
+  const [isScored, setIsScored] = useState(false);
+  const [isScoring, setIsScoring] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const walletAddress = walletClient?.account?.address ?? null;
+
+  const mmPublic = useMemo(() => {
+    if (!publicClient) return null;
+    return new MarchMadnessPublicClient(publicClient, CONTRACT_ADDRESS);
+  }, [publicClient]);
+
+  const mmUser = useMemo(() => {
+    if (!authenticated || !publicClient || !walletClient || !walletAddress)
+      return null;
+    return new MarchMadnessUserClient(
+      publicClient,
+      walletClient,
+      CONTRACT_ADDRESS
+    );
+  }, [authenticated, publicClient, walletClient, walletAddress]);
+
+  useEffect(() => {
+    if (!mmPublic || !targetAddress) return;
+
+    const fetch = async () => {
+      setIsLoading(true);
+      try {
+        const [rpa, scored] = await Promise.all([
+          mmPublic.getResultsPostedAt(),
+          mmPublic.getIsScored(targetAddress as Address),
+        ]);
+        setResultsPostedAt(rpa);
+        setIsScored(scored);
+      } catch {
+        // Silently ignore poll errors
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetch();
+    const id = setInterval(fetch, 30_000);
+    return () => clearInterval(id);
+  }, [mmPublic, targetAddress]);
+
+  const scoringWindowClosesAt =
+    resultsPostedAt !== null && resultsPostedAt > 0n
+      ? resultsPostedAt + SCORING_DURATION
+      : null;
+
+  const isWindowOpen =
+    resultsPostedAt !== null &&
+    resultsPostedAt > 0n &&
+    nowSeconds() < (scoringWindowClosesAt ?? 0n);
+
+  const canScore = isWindowOpen && !isScored && mmUser !== null;
+
+  const scoreBracket = useCallback(async (): Promise<`0x${string}`> => {
+    if (!mmUser) throw new Error("Wallet not connected");
+    if (!targetAddress) throw new Error("No target address");
+    setIsScoring(true);
+    setError(null);
+    try {
+      const hash = await mmUser.scoreBracket(targetAddress as Address);
+      setIsScored(true);
+      return hash;
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to score bracket";
+      setError(msg);
+      throw err;
+    } finally {
+      setIsScoring(false);
+    }
+  }, [mmUser, targetAddress]);
+
+  return {
+    isScored,
+    canScore,
+    scoreBracket,
+    isScoring,
+    error,
+    isLoading,
+  };
+}

--- a/packages/web/src/hooks/useWinningsState.ts
+++ b/packages/web/src/hooks/useWinningsState.ts
@@ -30,9 +30,12 @@ export interface WinningsState {
   isWinner: boolean;
   canClaim: boolean;
   canClaimEntryFee: boolean;
+  canScore: boolean;
   collectWinnings: () => Promise<`0x${string}`>;
   collectEntryFee: () => Promise<`0x${string}`>;
+  scoreBracket: () => Promise<`0x${string}`>;
   isCollecting: boolean;
+  isScoring: boolean;
   error: string | null;
   isLoading: boolean;
 }
@@ -61,6 +64,7 @@ export function useWinningsState(): WinningsState {
   } | null>(null);
 
   const [isCollecting, setIsCollecting] = useState(false);
+  const [isScoring, setIsScoring] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -173,6 +177,8 @@ export function useWinningsState(): WinningsState {
     numWinners > 0n;
 
   const canClaim = isWinner && isWindowClosed && !hasCollected;
+  const canScore =
+    isWindowOpen && !walletIsScored && hasEntry && mmUser !== null;
 
   const noContestAt =
     submissionDeadline !== null ? submissionDeadline + RESULTS_DEADLINE : null;
@@ -237,6 +243,28 @@ export function useWinningsState(): WinningsState {
     }
   }, [mmUser, walletKey, walletData]);
 
+  const scoreBracket = useCallback(async (): Promise<`0x${string}`> => {
+    if (!mmUser) throw new Error("Wallet not connected");
+    if (!walletAddress) throw new Error("No wallet address");
+    setIsScoring(true);
+    setError(null);
+    try {
+      const hash = await mmUser.scoreBracket(walletAddress);
+      // Optimistically mark as scored
+      if (walletKey && walletData && walletData.owner === walletKey) {
+        setWalletData({ ...walletData, isScored: true });
+      }
+      return hash;
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to score bracket";
+      setError(msg);
+      throw err;
+    } finally {
+      setIsScoring(false);
+    }
+  }, [mmUser, walletAddress, walletKey, walletData]);
+
   return {
     resultsPostedAt,
     isWindowOpen,
@@ -251,9 +279,12 @@ export function useWinningsState(): WinningsState {
     isWinner,
     canClaim,
     canClaimEntryFee,
+    canScore,
     collectWinnings,
     collectEntryFee,
+    scoreBracket,
     isCollecting,
+    isScoring,
     error,
     isLoading,
   };

--- a/packages/web/src/pages/BracketViewerPage.tsx
+++ b/packages/web/src/pages/BracketViewerPage.tsx
@@ -1,10 +1,11 @@
 import { useParams, Link } from "react-router-dom";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { validateBracket, scoreBracketPartial } from "@march-madness/client";
 
 import { BracketView } from "../components/BracketView";
 import { useEntries } from "../hooks/useEntries";
+import { useBracketScoringState } from "../hooks/useBracketScoringState";
 import { useReadOnlyBracket } from "../hooks/useReadOnlyBracket";
 import { useTeamProbs } from "../hooks/useTeamProbs";
 import { useTournamentStatus } from "../hooks/useTournamentStatus";
@@ -15,10 +16,17 @@ export function BracketViewerPage() {
   const { entries, loading: entriesLoading } = useEntries();
   const { status: tournamentStatus } = useTournamentStatus();
   const { teamProbs } = useTeamProbs();
+  const {
+    canScore,
+    scoreBracket,
+    isScoring,
+    error: scoringError,
+  } = useBracketScoringState(address);
+  const [scoreTxHash, setScoreTxHash] = useState<`0x${string}` | null>(null);
 
   const entry =
     address && entries
-      ? (entries[address.toLowerCase()] ?? entries[address])
+      ? entries[address.toLowerCase()] ?? entries[address]
       : null;
   const bracketHex =
     entry?.bracket && validateBracket(entry.bracket)
@@ -35,6 +43,15 @@ export function BracketViewerPage() {
   const getGamesForRound = useMemo(() => {
     return (round: number) => games.filter((g) => g.round === round);
   }, [games]);
+
+  const handleScore = async () => {
+    try {
+      const hash = await scoreBracket();
+      setScoreTxHash(hash);
+    } catch {
+      // error surfaced via scoringError
+    }
+  };
 
   if (entriesLoading) {
     return (
@@ -84,16 +101,40 @@ export function BracketViewerPage() {
             </p>
           )}
         </div>
-        {score && (
-          <div className="text-right">
-            <div className="text-2xl font-bold text-text-primary">
-              {score.current}
+        <div className="flex flex-col items-end gap-2">
+          {score && (
+            <div className="text-right">
+              <div className="text-2xl font-bold text-text-primary">
+                {score.current}
+              </div>
+              <div className="text-xs text-text-muted">
+                max {score.maxPossible}
+              </div>
             </div>
-            <div className="text-xs text-text-muted">
-              max {score.maxPossible}
+          )}
+          {canScore && (
+            <div className="text-right">
+              {scoringError && (
+                <p className="text-xs text-red-400 mb-1">{scoringError}</p>
+              )}
+              {scoreTxHash ? (
+                <p className="text-xs text-success font-mono">
+                  Scored:{" "}
+                  {`${scoreTxHash.slice(0, 10)}…${scoreTxHash.slice(-6)}`}
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleScore}
+                  disabled={isScoring}
+                  className="px-3 py-1 rounded-lg bg-accent text-bg-primary font-semibold text-xs hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isScoring ? "Scoring..." : "Score Bracket"}
+                </button>
+              )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <BracketView


### PR DESCRIPTION
## Summary

- Adds **"Score My Bracket"** button to the `WinningsBanner` on the leaderboard — visible when the scoring window is open and the connected wallet's bracket hasn't been scored on-chain yet
- Adds **"Score Bracket"** button to `BracketViewerPage` — visible for any unscored bracket during the scoring window (anyone can trigger scoring for any address)
- New `useBracketScoringState(address)` hook polls `getResultsPostedAt` + `getIsScored(targetAddress)` every 30s and exposes `canScore`, `scoreBracket()`, `isScoring`
- `useWinningsState` gains `canScore`, `scoreBracket()`, and `isScoring` fields

Both buttons call `mmUser.scoreBracket(address)` — the existing transparent contract write. No contract changes.

## Test plan

- [ ] Seed Redis with post-results state (scoring window open), start server + frontend
- [ ] Leaderboard: connect wallet with unscored entry → "Score My Bracket" button appears in banner → clicking sends tx → hash shown, button replaced
- [ ] Bracket viewer (`/bracket/:address`): navigate to an unscored bracket → "Score Bracket" button appears top-right → clicking sends tx → hash shown
- [ ] After scoring: button no longer appears (optimistic update + next poll confirms)
- [ ] Outside scoring window: no buttons appear
- [ ] `bun typecheck` passes in `packages/web`