### PR TITLE
fix: restore previewScore, fix scoring window check, dedupe constants

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -156,6 +156,15 @@ export class MarchMadnessPublicClient {
     return this.contract.read.hasCollectedWinnings([account], opts);
   }
 
+  /** Preview what score an account would receive against candidate results. */
+  async previewScore(
+    account: Address,
+    rawResults: `0x${string}`,
+    opts: ReadOptions = {},
+  ): Promise<number> {
+    return this.contract.read.previewScore([account, rawResults], opts);
+  }
+
   /** Whether an address has already collected their entry fee refund (no-contest). */
   async getHasCollectedEntryFee(
     account: Address,

--- a/packages/web/src/hooks/useBracketScoringState.ts
+++ b/packages/web/src/hooks/useBracketScoringState.ts
@@ -7,9 +7,7 @@ import {
 } from "@march-madness/client";
 import type { Address } from "viem";
 
-import { CONTRACT_ADDRESS } from "../lib/constants";
-
-const SCORING_DURATION = 7n * 24n * 3600n; // 7 days in seconds
+import { CONTRACT_ADDRESS, SCORING_DURATION } from "../lib/constants";
 
 function nowSeconds(): bigint {
   return BigInt(Math.floor(Date.now() / 1000));

--- a/packages/web/src/hooks/useGroupWinningsState.ts
+++ b/packages/web/src/hooks/useGroupWinningsState.ts
@@ -12,9 +12,11 @@ import type {
   MemberData,
 } from "@march-madness/client";
 
-import { CONTRACT_ADDRESS, GROUPS_CONTRACT_ADDRESS } from "../lib/constants";
-
-const SCORING_DURATION = 7n * 24n * 3600n; // 7 days in seconds
+import {
+  CONTRACT_ADDRESS,
+  GROUPS_CONTRACT_ADDRESS,
+  SCORING_DURATION,
+} from "../lib/constants";
 
 function nowSeconds(): bigint {
   return BigInt(Math.floor(Date.now() / 1000));

--- a/packages/web/src/hooks/useWinningsState.ts
+++ b/packages/web/src/hooks/useWinningsState.ts
@@ -6,11 +6,11 @@ import {
   MarchMadnessUserClient,
 } from "@march-madness/client";
 
-import { CONTRACT_ADDRESS } from "../lib/constants";
-
-// Contract constants — unchanging
-const SCORING_DURATION = 7n * 24n * 3600n; // 7 days in seconds
-const RESULTS_DEADLINE = 90n * 24n * 3600n; // 90 days in seconds
+import {
+  CONTRACT_ADDRESS,
+  SCORING_DURATION,
+  RESULTS_DEADLINE,
+} from "../lib/constants";
 
 function nowSeconds(): bigint {
   return BigInt(Math.floor(Date.now() / 1000));
@@ -170,9 +170,13 @@ export function useWinningsState(): WinningsState {
     numWinners > 0n;
 
   const canClaim = isWinner && isWindowClosed && !hasCollected;
-  const canScore =
+  const isWindowOpen =
     resultsPostedAt !== null &&
     resultsPostedAt > 0n &&
+    !isWindowClosed;
+
+  const canScore =
+    isWindowOpen &&
     !walletIsScored &&
     hasEntry &&
     mmUser !== null;

--- a/packages/web/src/lib/constants.ts
+++ b/packages/web/src/lib/constants.ts
@@ -59,6 +59,12 @@ export const SEED_ORDER = [
   1, 16, 8, 9, 5, 12, 4, 13, 6, 11, 3, 14, 7, 10, 2, 15,
 ];
 
+/** Scoring window duration — must match MarchMadness.SCORING_DURATION */
+export const SCORING_DURATION = 7n * 24n * 3600n; // 7 days in seconds
+
+/** Results deadline — must match MarchMadness.RESULTS_DEADLINE */
+export const RESULTS_DEADLINE = 90n * 24n * 3600n; // 90 days in seconds
+
 /** Round names */
 export const ROUND_NAMES = [
   "Round of 64",


### PR DESCRIPTION
## Summary

Fixes from PR #294 review:

- **Restore `previewScore()`** to `MarchMadnessPublicClient` — was deleted during merge conflict resolution, breaking `submit-results.ts` and `score-preview.ts`
- **Fix `useWinningsState.canScore`** — was missing the scoring window check, so the leaderboard "Score My Bracket" button would show after the 7-day window and cause on-chain reverts. Now matches `useBracketScoringState` behavior.
- **Dedupe `SCORING_DURATION` / `RESULTS_DEADLINE`** — extracted to `constants.ts` instead of hardcoding in 3 separate hooks

## Test plan
- [ ] `bun run --filter @march-madness/client typecheck` passes
- [ ] `bun run --filter @march-madness/web typecheck` passes
- [ ] Verify `previewScore` is callable from `submit-results.ts` and `score-preview.ts`
- [ ] After scoring window closes, "Score My Bracket" button no longer appears on leaderboard